### PR TITLE
Split off YoloV3 image preprocessing from standard image loading

### DIFF
--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadImageTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadImageTask.kt
@@ -1,0 +1,48 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.validator.path.PathValidator
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.util.singleAssign
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+/**
+ * Loads an image from a file.
+ */
+class LoadImageTask(name: String) : Task(name), KoinComponent {
+
+    /**
+     * The file path to load this data from.
+     */
+    var imagePath: String by singleAssign()
+
+    /**
+     * The output the image will be stored in.
+     */
+    var imageOutput: Variable by singleAssign()
+
+    /**
+     * Validates the [imagePath].
+     */
+    private val pathValidator: PathValidator by inject()
+
+    override val imports = setOf(
+        Import.ModuleAndIdentifier("PIL", "Image")
+    )
+
+    override val inputs: Set<Variable> = emptySet()
+
+    override val outputs: Set<Variable>
+        get() = setOf(imageOutput)
+
+    override val dependencies: Set<Code<*>> = emptySet()
+
+    override fun isConfiguredCorrectly() = pathValidator.isValidPathName(imagePath) &&
+        super.isConfiguredCorrectly()
+
+    override fun code() = """
+        |${imageOutput.name} = Image.open('$imagePath')
+    """.trimMargin()
+}

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/MakeNewInferenceSession.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/MakeNewInferenceSession.kt
@@ -8,6 +8,9 @@ import edu.wpi.axon.util.singleAssign
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
+/**
+ * Creates a new ONNX InferenceSession.
+ */
 class MakeNewInferenceSession(name: String) : Task(name), KoinComponent {
 
     /**

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/yolov3/LoadYoloV3ImageData.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/yolov3/LoadYoloV3ImageData.kt
@@ -1,24 +1,22 @@
-package edu.wpi.axon.dsl.task
+package edu.wpi.axon.dsl.task.yolov3
 
 import edu.wpi.axon.dsl.Code
 import edu.wpi.axon.dsl.Import
-import edu.wpi.axon.dsl.validator.path.PathValidator
+import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
-import org.koin.core.KoinComponent
-import org.koin.core.inject
 
 /**
  * Loads an image.
  *
  * TODO: Validate image format
  */
-class LoadImageData(name: String) : Task(name), KoinComponent {
+class LoadYoloV3ImageData(name: String) : Task(name) {
 
     /**
-     * The file path to load this data from.
+     * The input holding the image.
      */
-    var imagePath: String by singleAssign()
+    var imageInput: Variable by singleAssign()
 
     /**
      * The output the image data will be stored in.
@@ -30,29 +28,21 @@ class LoadImageData(name: String) : Task(name), KoinComponent {
      */
     var imageSizeOutput: Variable by singleAssign()
 
-    /**
-     * Validates the [imagePath].
-     */
-    private val pathValidator: PathValidator by inject()
-
     override val imports = setOf(
         Import.ModuleAndIdentifier("PIL", "Image"),
         Import.ModuleAndName("numpy", "np")
     )
 
-    override val inputs: Set<Variable> = emptySet()
+    override val inputs: Set<Variable>
+        get() = setOf(imageInput)
 
     override val outputs: Set<Variable>
         get() = setOf(imageDataOutput, imageSizeOutput)
 
     override val dependencies: Set<Code<*>> = emptySet()
 
-    override fun isConfiguredCorrectly() = pathValidator.isValidPathName(imagePath) &&
-        super.isConfiguredCorrectly()
-
     override fun code() = """
-        |$name = Image.open('$imagePath')
-        |${imageDataOutput.name} = preprocess($name)
-        |${imageSizeOutput.name} = np.array([$name.size[1], $name.size[0]], dtype=np.float32).reshape(1, 2)
+        |${imageDataOutput.name} = preprocessYoloV3(${imageInput.name})
+        |${imageSizeOutput.name} = np.array([${imageInput.name}.size[1], ${imageInput.name}.size[0]], dtype=np.float32).reshape(1, 2)
     """.trimMargin()
 }

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/yolov3/YoloV3PostprocessTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/yolov3/YoloV3PostprocessTask.kt
@@ -35,6 +35,6 @@ class YoloV3PostprocessTask(name: String) : Task(name) {
         get() = emptySet()
 
     override fun code() = """
-        |${output.name} = postprocessYolov3(${input.name})
+        |${output.name} = postprocessYoloV3(${input.name})
     """.trimMargin()
 }

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
@@ -93,18 +93,6 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
             lastTask = postProcessTask
         }
 
-        assertThat(
-            dsl.computeImports(), equalTo(
-                setOf(
-                    Import.ModuleOnly("onnxruntime"),
-                    Import.ModuleAndIdentifier("PIL", "Image"),
-                    Import.ModuleOnly("onnx"),
-                    Import.ModuleAndIdentifier("axon", "postprocessYolov3"),
-                    Import.ModuleAndName("numpy", "np")
-                )
-            )
-        )
-
         val code = dsl.code()
         assertEquals(
             """

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
@@ -4,15 +4,16 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import edu.wpi.axon.dsl.container.DefaultPolymorphicNamedDomainObjectContainer
 import edu.wpi.axon.dsl.task.InferenceTask
+import edu.wpi.axon.dsl.task.LoadClassLabels
+import edu.wpi.axon.dsl.task.LoadImageTask
+import edu.wpi.axon.dsl.task.MakeNewInferenceSession
+import edu.wpi.axon.dsl.task.yolov3.ConstructYoloV3ImageInput
+import edu.wpi.axon.dsl.task.yolov3.LoadYoloV3ImageData
 import edu.wpi.axon.dsl.task.yolov3.YoloV3PostprocessTask
 import edu.wpi.axon.dsl.validator.path.DefaultPathValidator
 import edu.wpi.axon.dsl.validator.path.PathValidator
 import edu.wpi.axon.dsl.validator.variablename.PythonVariableNameValidator
 import edu.wpi.axon.dsl.validator.variablename.VariableNameValidator
-import edu.wpi.axon.dsl.task.yolov3.ConstructYoloV3ImageInput
-import edu.wpi.axon.dsl.task.LoadClassLabels
-import edu.wpi.axon.dsl.task.LoadImageData
-import edu.wpi.axon.dsl.task.MakeNewInferenceSession
 import edu.wpi.axon.dsl.variable.Variable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -60,10 +61,16 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
 
             requireGeneration(classes)
 
+            val loadedImage by variables.creating(Variable::class)
+            val loadImageTask by tasks.running(LoadImageTask::class) {
+                imagePath = "horses.jpg"
+                imageOutput = loadedImage
+            }
+
             val imageData by variables.creating(Variable::class)
             val imageSize by variables.creating(Variable::class)
-            val loadImageData by tasks.running(LoadImageData::class) {
-                imagePath = "horses.jpg"
+            val loadImageData by tasks.running(LoadYoloV3ImageData::class) {
+                imageInput = loadedImage
                 imageDataOutput = imageData
                 imageSizeOutput = imageSize
             }
@@ -104,15 +111,16 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
             |
             |session = onnxruntime.InferenceSession('yolov3.onnx')
             |
-            |loadImageData = Image.open('horses.jpg')
-            |imageData = preprocess(loadImageData)
-            |imageSize = np.array([loadImageData.size[1], loadImageData.size[0]], dtype=np.float32).reshape(1, 2)
+            |loadedImage = Image.open('horses.jpg')
+            |
+            |imageData = preprocessYoloV3(loadedImage)
+            |imageSize = np.array([loadedImage.size[1], loadedImage.size[0]], dtype=np.float32).reshape(1, 2)
             |
             |inferenceInput = {session.get_inputs()[0].name: imageData, session.get_inputs()[1].name: imageSize}
             |
             |inferenceOutput = session.run(None, inferenceInput)
             |
-            |postProcessedOutput = postprocessYolov3(inferenceOutput)
+            |postProcessedOutput = postprocessYoloV3(inferenceOutput)
             |
             |
             |classes = [line.rstrip('\n') for line in open('coco_classes.txt')]


### PR DESCRIPTION
### Description of the Change

This PR splits YoloV3-specific image preprocessing from more standard image loading.

### Motivation

I didn't realize these were too tightly coupled during #3.

### Verification Process

Amended the DSL integration test.

### Applicable Issues

None.
