### PR TITLE
Add import validation

### DIFF
--- a/core/config/detekt/config.yml
+++ b/core/config/detekt/config.yml
@@ -95,7 +95,7 @@ complexity:
     threshold: 6
   NestedBlockDepth:
     active: true
-    threshold: 4
+    threshold: 5
   StringLiteralDuplication:
     active: true
     threshold: 5

--- a/core/dsl-interface/dsl-interface.gradle.kts
+++ b/core/dsl-interface/dsl-interface.gradle.kts
@@ -1,8 +1,14 @@
 description = "Interfaces and APIs for the script generator DSL."
 
+fun DependencyHandler.arrow(name: String) =
+    create(group = "io.arrow-kt", name = name, version = property("arrow.version") as String)
+
 fun DependencyHandler.koin(name: String) =
     create(group = "org.koin", name = name, version = property("koin.version") as String)
 
 dependencies {
+    api(arrow("arrow-core-data"))
+    api(arrow("arrow-extras-data"))
+
     api(koin("koin-core"))
 }

--- a/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/Code.kt
+++ b/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/Code.kt
@@ -1,5 +1,6 @@
 package edu.wpi.axon.dsl
 
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.variable.Variable
 
 typealias AnyCode = Code<Code<*>>

--- a/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/Import.kt
+++ b/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/Import.kt
@@ -1,4 +1,4 @@
-package edu.wpi.axon.dsl
+package edu.wpi.axon.dsl.imports
 
 /**
  * An import statement.

--- a/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/Import.kt
+++ b/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/Import.kt
@@ -3,13 +3,15 @@ package edu.wpi.axon.dsl.imports
 /**
  * An import statement.
  *
+ * @param components The component parts of the import (not including syntax).
+ *
  * TODO: Make a DSL to write Imports like:
  * ```kotlin
  * Import { from "axon" import "preprocessYolov3" }
  * Import { import "numpy" as "np" }
  * ```
  */
-sealed class Import {
+sealed class Import(val components: Set<String>) {
 
     /**
      * This method must be pure.
@@ -18,19 +20,21 @@ sealed class Import {
      */
     abstract fun code(): String
 
-    data class ModuleOnly(val module: String) : Import() {
+    data class ModuleOnly(val module: String) : Import(setOf(module)) {
         override fun code() = "import $module"
     }
 
-    data class ModuleAndIdentifier(val module: String, val identifier: String) : Import() {
+    data class ModuleAndIdentifier(val module: String, val identifier: String) :
+        Import(setOf(module, identifier)) {
         override fun code() = "from $module import $identifier"
     }
 
-    data class ModuleAndName(val module: String, val name: String) : Import() {
+    data class ModuleAndName(val module: String, val name: String) : Import(setOf(module, name)) {
         override fun code() = "import $module as $name"
     }
 
-    data class FullImport(val module: String, val identifier: String, val name: String) : Import() {
+    data class FullImport(val module: String, val identifier: String, val name: String) :
+        Import(setOf(module, identifier, name)) {
         override fun code() = "from $module import $identifier as $name"
     }
 }

--- a/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/ImportValidator.kt
+++ b/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/ImportValidator.kt
@@ -1,16 +1,18 @@
 package edu.wpi.axon.dsl.imports
 
+import arrow.data.Nel
+import arrow.data.Validated
+
 /**
  * Validates sets of Imports.
  */
 interface ImportValidator {
 
     /**
-     * Validates that the [imports] do not conflict with each other. If any conflict, they will
-     * be fixed with a best-effort strategy.
+     * Validates that the [imports] do not conflict with each other.
      *
      * @param imports The imports to validate.
-     * @return The (possibly) fixed set of imports.
+     * @return Either the original imports or a list of invalid imports.
      */
-    fun validateAndFixImports(imports: Set<Import>): Set<Import>
+    fun validateImports(imports: Set<Import>): Validated<Nel<Import>, Set<Import>>
 }

--- a/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/ImportValidator.kt
+++ b/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/imports/ImportValidator.kt
@@ -1,0 +1,16 @@
+package edu.wpi.axon.dsl.imports
+
+/**
+ * Validates sets of Imports.
+ */
+interface ImportValidator {
+
+    /**
+     * Validates that the [imports] do not conflict with each other. If any conflict, they will
+     * be fixed with a best-effort strategy.
+     *
+     * @param imports The imports to validate.
+     * @return The (possibly) fixed set of imports.
+     */
+    fun validateAndFixImports(imports: Set<Import>): Set<Import>
+}

--- a/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/task/Task.kt
+++ b/core/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/task/Task.kt
@@ -7,14 +7,12 @@ import edu.wpi.axon.dsl.Configurable
 /**
  * A [Task] is analogous to a method call. If this [Task] has an(y) output variable(s), it should
  * assign to them during [Code.code].
- *
- * @param name The name of this task. This does now have an impact on the generated code, it is only
- * used to assure task uniqueness.
  */
-abstract class Task(val name: String) : Configurable, AnyCode {
+interface Task : Configurable, AnyCode {
 
-    override fun isConfiguredCorrectly() =
-        inputs.all { it.isConfiguredCorrectly() } && outputs.all { it.isConfiguredCorrectly() }
-
-    override fun toString() = "Task(name='$name', class='${this::class.simpleName}')"
+    /**
+     * The name of this task. This does now have an impact on the generated code, it is only used to
+     * assure task uniqueness.
+     */
+    val name: String
 }

--- a/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockTask.kt
+++ b/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockTask.kt
@@ -5,7 +5,7 @@ import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import java.util.concurrent.CountDownLatch
 
-class MockTask(name: String) : Task(name) {
+class MockTask(override val name: String) : Task {
 
     override val imports: Set<Import> = emptySet()
     override val inputs: MutableSet<Variable> = mutableSetOf()

--- a/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockTask.kt
+++ b/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockTask.kt
@@ -1,5 +1,6 @@
 package edu.wpi.axon.dsl
 
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import java.util.concurrent.CountDownLatch

--- a/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockTask.kt
+++ b/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockTask.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch
 
 class MockTask(override val name: String) : Task {
 
-    override val imports: Set<Import> = emptySet()
+    override val imports: MutableSet<Import> = mutableSetOf()
     override val inputs: MutableSet<Variable> = mutableSetOf()
     override val outputs: MutableSet<Variable> = mutableSetOf()
     override val dependencies: MutableSet<AnyCode> = mutableSetOf()

--- a/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/TestUtil.kt
+++ b/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/TestUtil.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.koin.core.module.Module
 
-internal fun Module.alwaysValidImportValidator() =
+fun Module.alwaysValidImportValidator() =
     single<ImportValidator> {
         mockk { every { validateImports(any()) } returns Valid(emptySet()) }
     }

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/KoinModules.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/KoinModules.kt
@@ -1,0 +1,15 @@
+package edu.wpi.axon.dsl
+
+import edu.wpi.axon.dsl.imports.DefaultImportValidator
+import edu.wpi.axon.dsl.imports.ImportValidator
+import edu.wpi.axon.dsl.validator.path.DefaultPathValidator
+import edu.wpi.axon.dsl.validator.path.PathValidator
+import edu.wpi.axon.dsl.validator.variablename.PythonVariableNameValidator
+import edu.wpi.axon.dsl.validator.variablename.VariableNameValidator
+import org.koin.dsl.module
+
+fun defaultModule() = module {
+    single<VariableNameValidator> { PythonVariableNameValidator() }
+    single<PathValidator> { DefaultPathValidator() }
+    single<ImportValidator> { DefaultImportValidator() }
+}

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
@@ -59,6 +59,7 @@ class ScriptGenerator(
             "The DSl was not configured correctly."
         }
 
+        // TODO: Don't throw in here
         (variables.values + tasks.values + requiredVariables)
             .filter { !it.isConfiguredCorrectly() }
             .let {

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
@@ -4,6 +4,7 @@ package edu.wpi.axon.dsl
 
 import com.google.common.graph.ImmutableGraph
 import edu.wpi.axon.dsl.container.PolymorphicNamedDomainObjectContainer
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/imports/DefaultImportValidator.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/imports/DefaultImportValidator.kt
@@ -1,0 +1,21 @@
+package edu.wpi.axon.dsl.imports
+
+import arrow.core.None
+import arrow.core.Some
+import arrow.data.Invalid
+import arrow.data.Nel
+import arrow.data.Valid
+import arrow.data.Validated
+
+class DefaultImportValidator : ImportValidator {
+
+    override fun validateImports(imports: Set<Import>): Validated<Nel<Import>, Set<Import>> {
+        val invalidImports = imports.filter { it.isInvalid() }
+        return when (val nel = Nel.fromList(invalidImports)) {
+            is Some -> Invalid(nel.t)
+            is None -> Valid(imports)
+        }
+    }
+
+    private fun Import.isInvalid() = components.any { it.contains(Regex("\\s")) }
+}

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/BaseTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/BaseTask.kt
@@ -1,12 +1,18 @@
 package edu.wpi.axon.dsl.task
 
+import arrow.data.Valid
+import edu.wpi.axon.dsl.imports.ImportValidator
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
 /**
  * Holds the common implementation details for Tasks.
  */
-abstract class BaseTask(override val name: String) : Task {
+abstract class BaseTask(override val name: String) : Task, KoinComponent {
 
-    // TODO: Add import validation
-    override fun isConfiguredCorrectly() =
+    private val importValidator: ImportValidator by inject()
+
+    override fun isConfiguredCorrectly() = importValidator.validateImports(imports) is Valid &&
         inputs.all { it.isConfiguredCorrectly() } && outputs.all { it.isConfiguredCorrectly() }
 
     override fun toString() = "Task(name='$name', class='${this::class.simpleName}')"

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/BaseTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/BaseTask.kt
@@ -1,0 +1,13 @@
+package edu.wpi.axon.dsl.task
+
+/**
+ * Holds the common implementation details for Tasks.
+ */
+abstract class BaseTask(override val name: String) : Task {
+
+    // TODO: Add import validation
+    override fun isConfiguredCorrectly() =
+        inputs.all { it.isConfiguredCorrectly() } && outputs.all { it.isConfiguredCorrectly() }
+
+    override fun toString() = "Task(name='$name', class='${this::class.simpleName}')"
+}

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/InferenceTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/InferenceTask.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
 

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/InferenceTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/InferenceTask.kt
@@ -6,9 +6,9 @@ import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
 
 /**
- * A [Task] that runs inference.
+ * Runs inference using the ONNX runtime.
  */
-class InferenceTask(name: String) : Task(name) {
+class InferenceTask(name: String) : BaseTask(name) {
 
     /**
      * The data input to the first layer of the model.

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadClassLabels.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadClassLabels.kt
@@ -13,7 +13,7 @@ import org.koin.core.inject
  *
  * TODO: Need to detect the format of the labels or maybe ask the user what it is in the UI
  */
-class LoadClassLabels(name: String) : Task(name), KoinComponent {
+class LoadClassLabels(name: String) : BaseTask(name), KoinComponent {
 
     /**
      * The path for the class labels file.

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadClassLabels.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadClassLabels.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.validator.path.PathValidator
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadImageTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadImageTask.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.validator.path.PathValidator
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadImageTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadImageTask.kt
@@ -11,7 +11,7 @@ import org.koin.core.inject
 /**
  * Loads an image from a file.
  */
-class LoadImageTask(name: String) : Task(name), KoinComponent {
+class LoadImageTask(name: String) : BaseTask(name), KoinComponent {
 
     /**
      * The file path to load this data from.

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/MakeNewInferenceSession.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/MakeNewInferenceSession.kt
@@ -11,7 +11,7 @@ import org.koin.core.inject
 /**
  * Creates a new ONNX InferenceSession.
  */
-class MakeNewInferenceSession(name: String) : Task(name), KoinComponent {
+class MakeNewInferenceSession(name: String) : BaseTask(name), KoinComponent {
 
     /**
      * The path to load the ONNX model from.

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/MakeNewInferenceSession.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/MakeNewInferenceSession.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.validator.path.PathValidator
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/EmptyBaseTask.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/EmptyBaseTask.kt
@@ -1,0 +1,13 @@
+package edu.wpi.axon.dsl
+
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.task.BaseTask
+import edu.wpi.axon.dsl.variable.Variable
+
+internal class EmptyBaseTask(name: String) : BaseTask(name) {
+    override val imports: MutableSet<Import> = mutableSetOf()
+    override val inputs: MutableSet<Variable> = mutableSetOf()
+    override val outputs: MutableSet<Variable> = mutableSetOf()
+    override val dependencies: MutableSet<Code<*>> = mutableSetOf()
+    override fun code() = ""
+}

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
@@ -3,20 +3,13 @@ package edu.wpi.axon.dsl
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import edu.wpi.axon.dsl.container.DefaultPolymorphicNamedDomainObjectContainer
-import edu.wpi.axon.dsl.imports.DefaultImportValidator
 import edu.wpi.axon.dsl.imports.Import
-import edu.wpi.axon.dsl.imports.ImportValidator
-import edu.wpi.axon.dsl.validator.path.DefaultPathValidator
-import edu.wpi.axon.dsl.validator.path.PathValidator
-import edu.wpi.axon.dsl.validator.variablename.PythonVariableNameValidator
-import edu.wpi.axon.dsl.validator.variablename.VariableNameValidator
 import edu.wpi.axon.dsl.variable.Variable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import org.koin.test.KoinTest
 import java.util.concurrent.CountDownLatch
 
@@ -32,10 +25,7 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
     @Test
     fun `code dependencies should be called`() {
         startKoin {
-            modules(module {
-                single<VariableNameValidator> { PythonVariableNameValidator() }
-                single<PathValidator> { DefaultPathValidator() }
-            })
+            modules(defaultModule())
         }
 
         val codeLatch = CountDownLatch(2)
@@ -61,10 +51,7 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
     @Test
     fun `tasks are not run multiple times`() {
         startKoin {
-            modules(module {
-                single<VariableNameValidator> { PythonVariableNameValidator() }
-                single<PathValidator> { DefaultPathValidator() }
-            })
+            modules(defaultModule())
         }
 
         val codeLatch = CountDownLatch(3)
@@ -90,10 +77,7 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
     @Test
     fun `two tasks that depend on the same task does not duplicate code gen`() {
         startKoin {
-            modules(module {
-                single<VariableNameValidator> { PythonVariableNameValidator() }
-                single<PathValidator> { DefaultPathValidator() }
-            })
+            modules(defaultModule())
         }
 
         val task1CodeLatch = CountDownLatch(2)
@@ -119,10 +103,7 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
     @Test
     fun `two tasks that depend on the same task linked by a variable does not duplicate code gen`() {
         startKoin {
-            modules(module {
-                single<VariableNameValidator> { PythonVariableNameValidator() }
-                single<PathValidator> { DefaultPathValidator() }
-            })
+            modules(defaultModule())
         }
 
         val task1CodeLatch = CountDownLatch(2)
@@ -154,11 +135,7 @@ internal class ScriptGeneratorIntegrationTest : KoinTest {
     @Test
     fun `a task with invalid imports makes the script invalid`() {
         startKoin {
-            modules(module {
-                single<VariableNameValidator> { PythonVariableNameValidator() }
-                single<PathValidator> { DefaultPathValidator() }
-                single<ImportValidator> { DefaultImportValidator() }
-            })
+            modules(defaultModule())
         }
 
         val script = ScriptGenerator(

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/TestUtil.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/TestUtil.kt
@@ -1,0 +1,13 @@
+package edu.wpi.axon.dsl
+
+import arrow.data.Valid
+import edu.wpi.axon.dsl.imports.ImportValidator
+import io.mockk.every
+import io.mockk.mockk
+import org.koin.core.module.Module
+
+internal fun Module.alwaysValidImportValidator() {
+    single<ImportValidator> {
+        mockk { every { validateImports(any()) } returns Valid(emptySet()) }
+    }
+}

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/TestUtil.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/TestUtil.kt
@@ -6,8 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.koin.core.module.Module
 
-internal fun Module.alwaysValidImportValidator() {
+internal fun Module.alwaysValidImportValidator() =
     single<ImportValidator> {
         mockk { every { validateImports(any()) } returns Valid(emptySet()) }
     }
-}

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/imports/DefaultImportValidatorTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/imports/DefaultImportValidatorTest.kt
@@ -1,0 +1,29 @@
+package edu.wpi.axon.dsl.imports
+
+import arrow.data.Valid
+import com.natpryce.hamkrest.assertion.assertThat
+import edu.wpi.axon.testutil.isInvalid
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class DefaultImportValidatorTest {
+
+    private val validator = DefaultImportValidator()
+
+    @Test
+    fun `a valid set of imports is passed through without modification`() {
+        val imports = setOf(
+            Import.ModuleOnly("import1"),
+            Import.ModuleOnly("import2"),
+            Import.ModuleAndIdentifier("import1", "id1")
+        )
+
+        assertEquals(validator.validateImports(imports), Valid(imports))
+    }
+
+    @Test
+    fun `spaces are not allowed in import names`() {
+        val imports = setOf(Import.ModuleOnly("import 1"))
+        assertThat(validator.validateImports(imports), isInvalid())
+    }
+}

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/BaseTaskTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/BaseTaskTest.kt
@@ -69,6 +69,7 @@ internal class BaseTaskTest : KoinTest {
         assertThat(task.isConfiguredCorrectly(), isFalse())
     }
 
+    @SuppressWarnings("LongParameterList")
     private fun stubTask(
         name: String = "task1",
         imports: Set<Import> = setOf(),

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/BaseTaskTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/BaseTaskTest.kt
@@ -2,9 +2,9 @@ package edu.wpi.axon.dsl.task
 
 import arrow.data.Invalid
 import arrow.data.Nel
-import arrow.data.Valid
 import com.natpryce.hamkrest.assertion.assertThat
 import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.alwaysValidImportValidator
 import edu.wpi.axon.dsl.configuredIncorrectly
 import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.imports.ImportValidator
@@ -30,9 +30,7 @@ internal class BaseTaskTest : KoinTest {
     fun `an invalid input means the task is invalid`() {
         startKoin {
             modules(module {
-                single<ImportValidator> {
-                    mockk { every { validateImports(any()) } returns Valid(emptySet()) }
-                }
+                alwaysValidImportValidator()
             })
         }
 
@@ -44,9 +42,7 @@ internal class BaseTaskTest : KoinTest {
     fun `an invalid output means the task is invalid`() {
         startKoin {
             modules(module {
-                single<ImportValidator> {
-                    mockk { every { validateImports(any()) } returns Valid(emptySet()) }
-                }
+                alwaysValidImportValidator()
             })
         }
 

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/BaseTaskTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/BaseTaskTest.kt
@@ -1,0 +1,90 @@
+package edu.wpi.axon.dsl.task
+
+import arrow.data.Invalid
+import arrow.data.Nel
+import arrow.data.Valid
+import com.natpryce.hamkrest.assertion.assertThat
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.configuredIncorrectly
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.imports.ImportValidator
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.testutil.isFalse
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+
+internal class BaseTaskTest : KoinTest {
+
+    @AfterEach
+    fun afterEach() {
+        stopKoin()
+    }
+
+    @Test
+    fun `an invalid input means the task is invalid`() {
+        startKoin {
+            modules(module {
+                single<ImportValidator> {
+                    mockk { every { validateImports(any()) } returns Valid(emptySet()) }
+                }
+            })
+        }
+
+        val task = stubTask(inputs = setOf(configuredIncorrectly()))
+        assertThat(task.isConfiguredCorrectly(), isFalse())
+    }
+
+    @Test
+    fun `an invalid output means the task is invalid`() {
+        startKoin {
+            modules(module {
+                single<ImportValidator> {
+                    mockk { every { validateImports(any()) } returns Valid(emptySet()) }
+                }
+            })
+        }
+
+        val task = stubTask(outputs = setOf(configuredIncorrectly()))
+        assertThat(task.isConfiguredCorrectly(), isFalse())
+    }
+
+    @Test
+    fun `an invalid import means the task is invalid`() {
+        val imports = setOf(Import.ModuleOnly(""))
+
+        val mockImportValidator = mockk<ImportValidator> {
+            every { validateImports(imports) } returns
+                Invalid(Nel.fromListUnsafe(imports.toList()))
+        }
+
+        startKoin {
+            modules(module {
+                single { mockImportValidator }
+            })
+        }
+
+        val task = stubTask(imports = imports)
+        assertThat(task.isConfiguredCorrectly(), isFalse())
+    }
+
+    private fun stubTask(
+        name: String = "task1",
+        imports: Set<Import> = setOf(),
+        inputs: Set<Variable> = setOf(),
+        outputs: Set<Variable> = setOf(),
+        dependencies: Set<Code<*>> = setOf(),
+        code: String = ""
+    ): Task = object : BaseTask(name) {
+        override val imports: Set<Import> = imports
+        override val inputs: Set<Variable> = inputs
+        override val outputs: Set<Variable> = outputs
+        override val dependencies: Set<Code<*>> = dependencies
+        override fun code() = code
+    }
+}

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/InferenceTaskTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/InferenceTaskTest.kt
@@ -1,19 +1,36 @@
 package edu.wpi.axon.dsl.task
 
 import com.natpryce.hamkrest.assertion.assertThat
+import edu.wpi.axon.dsl.alwaysValidImportValidator
 import edu.wpi.axon.dsl.configuredCorrectly
 import edu.wpi.axon.dsl.configuredIncorrectly
 import edu.wpi.axon.testutil.isFalse
 import edu.wpi.axon.testutil.isTrue
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
 
-internal class InferenceTaskTest {
+internal class InferenceTaskTest : KoinTest {
 
     private val inferenceTaskName = "task"
 
+    @AfterEach
+    fun afterEach() {
+        stopKoin()
+    }
+
     @Test
     fun `input cannot be uninitialized`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = InferenceTask(inferenceTaskName).apply {
             inferenceSession = configuredCorrectly()
             output = configuredCorrectly()
@@ -24,6 +41,12 @@ internal class InferenceTaskTest {
 
     @Test
     fun `inferenceSession cannot be uninitialized`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = InferenceTask(inferenceTaskName).apply {
             input = configuredCorrectly()
             output = configuredCorrectly()
@@ -34,6 +57,12 @@ internal class InferenceTaskTest {
 
     @Test
     fun `output cannot be uninitialized`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = InferenceTask(inferenceTaskName).apply {
             input = configuredCorrectly()
             inferenceSession = configuredCorrectly()
@@ -44,6 +73,12 @@ internal class InferenceTaskTest {
 
     @Test
     fun `all inputs must be configured correctly`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = InferenceTask(inferenceTaskName).apply {
             input = configuredCorrectly()
             inferenceSession = configuredIncorrectly()
@@ -55,6 +90,12 @@ internal class InferenceTaskTest {
 
     @Test
     fun `all outputs must be configured correctly`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = InferenceTask(inferenceTaskName).apply {
             input = configuredCorrectly()
             inferenceSession = configuredCorrectly()
@@ -66,6 +107,12 @@ internal class InferenceTaskTest {
 
     @Test
     fun `configured correctly when all parameters are non-null and all inputs and outputs are configured correctly`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = InferenceTask(inferenceTaskName).apply {
             input = configuredCorrectly()
             inferenceSession = configuredCorrectly()

--- a/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/ConstructYoloV3ImageInput.kt
+++ b/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/ConstructYoloV3ImageInput.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.tasks.yolov3
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/ConstructYoloV3ImageInput.kt
+++ b/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/ConstructYoloV3ImageInput.kt
@@ -2,14 +2,14 @@ package edu.wpi.axon.tasks.yolov3
 
 import edu.wpi.axon.dsl.Code
 import edu.wpi.axon.dsl.imports.Import
-import edu.wpi.axon.dsl.task.Task
+import edu.wpi.axon.dsl.task.BaseTask
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
 
 /**
  * Constructs the input argument for the YoloV3 model.
  */
-class ConstructYoloV3ImageInput(name: String) : Task(name) {
+class ConstructYoloV3ImageInput(name: String) : BaseTask(name) {
 
     var imageDataInput: Variable by singleAssign()
     var imageSizeInput: Variable by singleAssign()

--- a/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/LoadYoloV3ImageData.kt
+++ b/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/LoadYoloV3ImageData.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.tasks.yolov3
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/LoadYoloV3ImageData.kt
+++ b/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/LoadYoloV3ImageData.kt
@@ -2,7 +2,7 @@ package edu.wpi.axon.tasks.yolov3
 
 import edu.wpi.axon.dsl.Code
 import edu.wpi.axon.dsl.imports.Import
-import edu.wpi.axon.dsl.task.Task
+import edu.wpi.axon.dsl.task.BaseTask
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
 
@@ -11,7 +11,7 @@ import edu.wpi.axon.util.singleAssign
  *
  * TODO: Validate image format
  */
-class LoadYoloV3ImageData(name: String) : Task(name) {
+class LoadYoloV3ImageData(name: String) : BaseTask(name) {
 
     /**
      * The input holding the image.

--- a/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/YoloV3PostprocessTask.kt
+++ b/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/YoloV3PostprocessTask.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.tasks.yolov3
 
 import edu.wpi.axon.dsl.Code
-import edu.wpi.axon.dsl.Import
+import edu.wpi.axon.dsl.imports.Import
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign

--- a/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/YoloV3PostprocessTask.kt
+++ b/core/tasks-yolov3/src/main/kotlin/edu/wpi/axon/tasks/yolov3/YoloV3PostprocessTask.kt
@@ -2,14 +2,14 @@ package edu.wpi.axon.tasks.yolov3
 
 import edu.wpi.axon.dsl.Code
 import edu.wpi.axon.dsl.imports.Import
-import edu.wpi.axon.dsl.task.Task
+import edu.wpi.axon.dsl.task.BaseTask
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
 
 /**
- * A [Task] that post-processes the output from a YoloV3 model.
+ * Post-processes the output from a YoloV3 model.
  */
-class YoloV3PostprocessTask(name: String) : Task(name) {
+class YoloV3PostprocessTask(name: String) : BaseTask(name) {
 
     /**
      * The input data, typically the output of [InferenceTask].

--- a/core/tasks-yolov3/src/test/kotlin/edu/wpi/axon/tasks/yolov3/YoloV3PostprocessTaskTest.kt
+++ b/core/tasks-yolov3/src/test/kotlin/edu/wpi/axon/tasks/yolov3/YoloV3PostprocessTaskTest.kt
@@ -1,17 +1,34 @@
 package edu.wpi.axon.tasks.yolov3
 
 import com.natpryce.hamkrest.assertion.assertThat
+import edu.wpi.axon.dsl.alwaysValidImportValidator
 import edu.wpi.axon.dsl.configuredCorrectly
 import edu.wpi.axon.testutil.isTrue
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
 
-internal class YoloV3PostprocessTaskTest {
+internal class YoloV3PostprocessTaskTest : KoinTest {
 
     private val taskName = "task"
 
+    @AfterEach
+    fun afterEach() {
+        stopKoin()
+    }
+
     @Test
     fun `input cannot be unconfigured`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = YoloV3PostprocessTask(taskName).apply {
             output = configuredCorrectly()
         }
@@ -21,6 +38,12 @@ internal class YoloV3PostprocessTaskTest {
 
     @Test
     fun `output cannot be unconfigured`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = YoloV3PostprocessTask(taskName).apply {
             input = configuredCorrectly()
         }
@@ -30,6 +53,12 @@ internal class YoloV3PostprocessTaskTest {
 
     @Test
     fun `configured correctly when all parameters are configured correctly`() {
+        startKoin {
+            modules(module {
+                alwaysValidImportValidator()
+            })
+        }
+
         val task = YoloV3PostprocessTask(taskName).apply {
             input = configuredCorrectly()
             output = configuredCorrectly()

--- a/core/tasks-yolov3/src/test/kotlin/edu/wpi/axon/tasks/yolov3/Yolov3IntegrationTest.kt
+++ b/core/tasks-yolov3/src/test/kotlin/edu/wpi/axon/tasks/yolov3/Yolov3IntegrationTest.kt
@@ -3,22 +3,18 @@ package edu.wpi.axon.tasks.yolov3
 import edu.wpi.axon.dsl.ScriptGenerator
 import edu.wpi.axon.dsl.container.DefaultPolymorphicNamedDomainObjectContainer
 import edu.wpi.axon.dsl.creating
+import edu.wpi.axon.dsl.defaultModule
 import edu.wpi.axon.dsl.running
 import edu.wpi.axon.dsl.task.InferenceTask
 import edu.wpi.axon.dsl.task.LoadClassLabels
 import edu.wpi.axon.dsl.task.LoadImageTask
 import edu.wpi.axon.dsl.task.MakeNewInferenceSession
-import edu.wpi.axon.dsl.validator.path.DefaultPathValidator
-import edu.wpi.axon.dsl.validator.path.PathValidator
-import edu.wpi.axon.dsl.validator.variablename.PythonVariableNameValidator
-import edu.wpi.axon.dsl.validator.variablename.VariableNameValidator
 import edu.wpi.axon.dsl.variable.Variable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import org.koin.test.KoinTest
 
 @Suppress("UNUSED_VARIABLE")
@@ -34,10 +30,7 @@ internal class Yolov3IntegrationTest : KoinTest {
     @Test
     fun `generate yolov3 run script`() {
         startKoin {
-            modules(module {
-                single<VariableNameValidator> { PythonVariableNameValidator() }
-                single<PathValidator> { DefaultPathValidator() }
-            })
+            modules(defaultModule())
         }
 
         val dsl = ScriptGenerator(

--- a/core/test-util/src/main/kotlin/edu/wpi/axon/testutil/HamkrestUtil.kt
+++ b/core/test-util/src/main/kotlin/edu/wpi/axon/testutil/HamkrestUtil.kt
@@ -1,5 +1,9 @@
 package edu.wpi.axon.testutil
 
+import arrow.core.Either
+import arrow.data.Invalid
+import arrow.data.Valid
+import arrow.data.Validated
 import com.natpryce.hamkrest.MatchResult
 import com.natpryce.hamkrest.Matcher
 import com.natpryce.hamkrest.describe
@@ -42,3 +46,36 @@ fun <K, V> mapHasElementWhere(predicate: Map.Entry<K, V>.() -> Boolean): Matcher
 fun isTrue(): Matcher<Boolean?> = equalTo(true)
 
 fun isFalse(): Matcher<Boolean?> = equalTo(false)
+
+fun <A, B> isLeft(): Matcher<Either<A, B>?> = object : Matcher<Either<A, B>?> {
+
+    override val description = "is Left"
+
+    override fun invoke(actual: Either<A, B>?) = when (actual) {
+        is Either.Left -> MatchResult.Match
+        is Either.Right -> MatchResult.Mismatch("was Right")
+        null -> MatchResult.Mismatch("was null")
+    }
+}
+
+fun <A, B> isRight(): Matcher<Either<A, B>?> = object : Matcher<Either<A, B>?> {
+
+    override val description = "is Right"
+
+    override fun invoke(actual: Either<A, B>?) = when (actual) {
+        is Either.Left -> MatchResult.Match
+        is Either.Right -> MatchResult.Mismatch("was Left")
+        null -> MatchResult.Mismatch("was null")
+    }
+}
+
+fun <A, B> isInvalid(): Matcher<Validated<A, B>?> = object : Matcher<Validated<A, B>?> {
+
+    override val description = "is Invalid"
+
+    override fun invoke(actual: Validated<A, B>?) = when (actual) {
+        is Invalid -> MatchResult.Match
+        is Valid -> MatchResult.Mismatch("was Valid")
+        null -> MatchResult.Mismatch("was null")
+    }
+}

--- a/core/test-util/test-util.gradle.kts
+++ b/core/test-util/test-util.gradle.kts
@@ -1,6 +1,12 @@
 description = "Utilities for testing the other projects."
 
+fun DependencyHandler.arrow(name: String) =
+    create(group = "io.arrow-kt", name = name, version = property("arrow.version") as String)
+
 dependencies {
+    api(arrow("arrow-core-data"))
+    api(arrow("arrow-extras-data"))
+
     api(
         group = "com.natpryce",
         name = "hamkrest",


### PR DESCRIPTION
### Description of the Change

This PR adds import validation by default in `BaseTask`.

### Motivation

Imports should be checked they do not contain whitespace, etc.

### Verification Process

New tests for import validation.

### Applicable Issues

None.
