### PR TITLE
Check for CodeGraph islands

### DIFF
--- a/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockUtil.kt
+++ b/core/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/MockUtil.kt
@@ -20,18 +20,18 @@ fun mockPathValidator(vararg pathValidations: Pair<String, Boolean>) =
         }
     }
 
-inline fun <reified T : Variable> configuredCorrectly(inputName: String? = null) =
+inline fun <reified T : Configurable> configuredCorrectly(inputName: String? = null) =
     mockk<T> {
-        if (inputName != null) {
+        if (inputName != null && this is Variable) {
             every { name } returns inputName
         }
 
         every { isConfiguredCorrectly() } returns true
     }
 
-inline fun <reified T : Variable> configuredIncorrectly(inputName: String? = null) =
+inline fun <reified T : Configurable> configuredIncorrectly(inputName: String? = null) =
     mockk<T> {
-        if (inputName != null) {
+        if (inputName != null && this is Variable) {
             every { name } returns inputName
         }
 

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
@@ -5,11 +5,13 @@ package edu.wpi.axon.dsl
 import arrow.core.Either
 import arrow.data.Invalid
 import arrow.data.Nel
-import arrow.data.Validated
+import arrow.data.ValidatedNel
+import arrow.data.invalidNel
 import arrow.data.valid
 import com.google.common.graph.ImmutableGraph
 import edu.wpi.axon.dsl.container.PolymorphicNamedDomainObjectContainer
 import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.task.EmptyBaseTask
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.util.singleAssign
@@ -59,12 +61,21 @@ class ScriptGenerator(
      * @param generateDebugComments Whether to insert debugging comments.
      * @return The entire generated script.
      */
-    fun code(generateDebugComments: Boolean = false): Validated<Nel<String>, String> {
+    fun code(generateDebugComments: Boolean = false): ValidatedNel<String, String> {
         if (!isConfiguredCorrectly()) {
-            return Invalid(Nel.just("$this is configured incorrectly."))
+            return "$this is configured incorrectly.".invalidNel()
         }
 
-        (variables.values + tasks.values + requiredVariables)
+        @Suppress("UNUSED_VARIABLE")
+        val finalCompositeTask by tasks.running(EmptyBaseTask::class) {
+            // Depend on what the user said was their last task so this runs after
+            dependencies += lastTask
+
+            // Add dependencies for any required variables
+            dependOnRequiredVariables(generateDebugComments)
+        }
+
+        (variables.values + tasks.values)
             .filter { !it.isConfiguredCorrectly() }
             .let {
                 if (it.isNotEmpty()) {
@@ -78,14 +89,12 @@ class ScriptGenerator(
         val graph = CodeGraph(tasks as PolymorphicNamedDomainObjectContainer<AnyCode>).graph
 
         return when (graph) {
-            is Either.Left -> Invalid(Nel.just(graph.a))
+            is Either.Left -> graph.a.invalidNel()
 
             is Either.Right -> buildString {
                 appendImports(generateDebugComments, graph.b)
                 append('\n')
-                appendTaskCode(generateDebugComments, graph.b, handledNodes)
-                append('\n')
-                appendRequiredVariables(generateDebugComments, handledNodes)
+                appendTaskCode(generateDebugComments, graph.b, finalCompositeTask, handledNodes)
             }.trim().valid()
         }
     }
@@ -134,6 +143,7 @@ class ScriptGenerator(
     private fun StringBuilder.appendTaskCode(
         generateDebugComments: Boolean,
         graph: ImmutableGraph<AnyCode>,
+        startingTask: AnyCode,
         handledNodes: MutableSet<AnyCode>
     ) {
         fun appendNode(node: AnyCode) {
@@ -156,27 +166,25 @@ class ScriptGenerator(
             }
         }
 
-        appendNode(lastTask)
+        appendNode(startingTask)
     }
 
     /**
      * Appends code for all the explicitly required variables.
      *
      * @param generateDebugComments Whether to insert debugging comments.
-     * @param handledNodes The nodes that code generation has already run for.
      */
-    private fun StringBuilder.appendRequiredVariables(
-        generateDebugComments: Boolean,
-        handledNodes: MutableSet<AnyCode>
+    private fun EmptyBaseTask.dependOnRequiredVariables(
+        generateDebugComments: Boolean
     ) {
         requiredVariables.forEach { variable ->
             tasks.forEach { _, task ->
-                if (task !in handledNodes && variable in task.outputs) {
+                if (variable in task.outputs) {
                     if (generateDebugComments) {
                         println("Generating $task because of required variable $variable")
                     }
 
-                    appendCode(task, generateDebugComments, handledNodes)
+                    dependencies += task
                 }
             }
         }

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/ScriptGenerator.kt
@@ -170,7 +170,7 @@ class ScriptGenerator(
     }
 
     /**
-     * Appends code for all the explicitly required variables.
+     * Adds dependencies on the tasks that output to any of the explicitly required variables.
      *
      * @param generateDebugComments Whether to insert debugging comments.
      */

--- a/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/EmptyBaseTask.kt
+++ b/core/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/EmptyBaseTask.kt
@@ -1,10 +1,10 @@
-package edu.wpi.axon.dsl
+package edu.wpi.axon.dsl.task
 
+import edu.wpi.axon.dsl.Code
 import edu.wpi.axon.dsl.imports.Import
-import edu.wpi.axon.dsl.task.BaseTask
 import edu.wpi.axon.dsl.variable.Variable
 
-internal data class EmptyBaseTask(override val name: String) : BaseTask(name) {
+data class EmptyBaseTask(override val name: String) : BaseTask(name) {
     override val imports: MutableSet<Import> = mutableSetOf()
     override val inputs: MutableSet<Variable> = mutableSetOf()
     override val outputs: MutableSet<Variable> = mutableSetOf()

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/CodeGraphTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/CodeGraphTest.kt
@@ -164,7 +164,7 @@ internal class CodeGraphTest {
         val task1 = codes["task1"]!!
         val task2 = codes["task2"]!!
 
-        // Don't connect task3 so it forms an islands
+        // Don't connect task3 so it forms an island
         task1.dependencies += task2
 
         val container = mockContainer(codes)

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/CodeGraphTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/CodeGraphTest.kt
@@ -5,6 +5,7 @@ package edu.wpi.axon.dsl
 import com.google.common.graph.EndpointPair
 import io.kotlintest.assertions.arrow.either.shouldBeLeft
 import io.kotlintest.assertions.arrow.either.shouldBeRight
+import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.equality.shouldBeEqualToUsingFields
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -18,6 +19,15 @@ internal class CodeGraphTest {
     @AfterEach
     fun afterEach() {
         stopKoin()
+    }
+
+    @Test
+    fun `an empty container generates an empty graph`() {
+        val graph = CodeGraph(mockContainer()).graph
+        graph.shouldBeRight {
+            it.nodes().shouldBeEmpty()
+            it.edges().shouldBeEmpty()
+        }
     }
 
     @Test
@@ -136,6 +146,26 @@ internal class CodeGraphTest {
         task1.dependencies += task2
         task1.outputs += variable1
         task2.inputs += variable1
+
+        val container = mockContainer(codes)
+        val graph = CodeGraph(container)
+        graph.graph.shouldBeLeft()
+    }
+
+    @Test
+    fun `islands are not allowed`() {
+        startKoin {
+            modules(module {
+                single { mockVariableNameValidator("variable1" to true) }
+            })
+        }
+
+        val codes = makeMockTasks("task1", "task2", "task3")
+        val task1 = codes["task1"]!!
+        val task2 = codes["task2"]!!
+
+        // Don't connect task3 so it forms an islands
+        task1.dependencies += task2
 
         val container = mockContainer(codes)
         val graph = CodeGraph(container)

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/MockContainer.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/MockContainer.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.fail
 import kotlin.reflect.KClass
 
 class MockContainer<T : Any>(
-    val backingMap: MutableMap<String, T>
+    private val backingMap: MutableMap<String, T>
 ) : PolymorphicNamedDomainObjectContainer<T>, Map<String, T> by backingMap {
     override fun <U : T> create(name: String, type: KClass<U>, configure: (U.() -> Unit)?): U {
         fail { "create is not implemented." }
@@ -13,9 +13,9 @@ class MockContainer<T : Any>(
 }
 
 @Suppress("UNCHECKED_CAST")
-fun mockContainer(
-    backingMap: MutableMap<String, out Any>
-): PolymorphicNamedDomainObjectContainer<AnyCode> = when (backingMap.values.first()) {
-    is AnyCode -> MockContainer(backingMap) as PolymorphicNamedDomainObjectContainer<AnyCode>
+internal fun mockContainer(
+    backingMap: MutableMap<String, out Any> = mutableMapOf()
+): PolymorphicNamedDomainObjectContainer<AnyCode> = when (backingMap.values.firstOrNull()) {
+    is AnyCode, null -> MockContainer(backingMap) as PolymorphicNamedDomainObjectContainer<AnyCode>
     else -> fail { "Unknown map value type." }
 }

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorIntegrationTest.kt
@@ -4,13 +4,13 @@ package edu.wpi.axon.dsl
 
 import edu.wpi.axon.dsl.container.DefaultPolymorphicNamedDomainObjectContainer
 import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.task.EmptyBaseTask
 import edu.wpi.axon.dsl.variable.Variable
 import edu.wpi.axon.testutil.KoinTestFixture
 import io.kotlintest.assertions.arrow.nel.shouldHaveSize
 import io.kotlintest.assertions.arrow.validation.shouldBeInvalid
 import io.kotlintest.assertions.arrow.validation.shouldBeValid
 import io.kotlintest.shouldBe
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.koin.core.context.startKoin
@@ -174,10 +174,7 @@ internal class ScriptGeneratorIntegrationTest : KoinTestFixture() {
             requireGeneration(var1)
         }
 
-        scriptGenerator.code().shouldBeValid { (code) ->
-            assertFalse(code.contains("task1"))
-            assertTrue(code.contains("task2"))
-        }
+        scriptGenerator.code().shouldBeInvalid()
     }
 
     @Test

--- a/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorTest.kt
+++ b/core/dsl/src/test/kotlin/edu/wpi/axon/dsl/ScriptGeneratorTest.kt
@@ -1,6 +1,7 @@
 package edu.wpi.axon.dsl
 
 import edu.wpi.axon.dsl.container.PolymorphicNamedDomainObjectContainer
+import edu.wpi.axon.dsl.task.EmptyBaseTask
 import edu.wpi.axon.dsl.task.Task
 import edu.wpi.axon.dsl.variable.Variable
 import io.kotlintest.assertions.arrow.nel.shouldHaveSize
@@ -46,17 +47,16 @@ internal class ScriptGeneratorTest {
 
     @Test
     fun `generate code with an incorrectly configured task`() {
-        val mockTask = mockk<MockTask> {
-            every { isConfiguredCorrectly() } returns false
-        }
-
         val mockVariableContainer = mockk<PolymorphicNamedDomainObjectContainer<Variable>> {
             every { values } returns emptyList()
         }
 
         val mockTaskContainer = mockk<PolymorphicNamedDomainObjectContainer<Task>> {
-            every { create("task1", MockTask::class, any()) } returns mockTask
-            every { values } returns listOf(mockTask)
+            every { create("task1", MockTask::class, any()) } returns configuredIncorrectly()
+            every {
+                create("finalCompositeTask", EmptyBaseTask::class, any())
+            } returns configuredCorrectly()
+            every { values } returns listOf(configuredIncorrectly())
         }
 
         val scriptGenerator = ScriptGenerator(mockVariableContainer, mockTaskContainer) {
@@ -67,9 +67,9 @@ internal class ScriptGeneratorTest {
             nel.shouldHaveSize(1)
         }
 
-        verify { mockTask.isConfiguredCorrectly() }
         verify { mockVariableContainer.values }
         verify { mockTaskContainer.create("task1", MockTask::class, any()) }
+        verify { mockTaskContainer.create("finalCompositeTask", EmptyBaseTask::class, any()) }
         verify { mockTaskContainer.values }
         confirmVerified(mockVariableContainer, mockTaskContainer)
     }


### PR DESCRIPTION
### Description of the Change

This PR adds validation in CodeGraph that the generated graph does not contain islands.

### Motivation

A CodeGraph should not contain irrelevant code; therefore, it should not contain multiple islands.

### Verification Process

Added unit tests for this.

### Applicable Issues

Closes #17.
