### PR TITLE
Add a Task for applying a layer delta

### DIFF
--- a/axon.gradle.kts
+++ b/axon.gradle.kts
@@ -28,6 +28,7 @@ val taskPropertyTestingProject = project(":task-property-testing")
 val tasksYolov3Project = project(":tasks-yolov3")
 val testUtilProject = project(":test-util")
 val tfLayerLoaderProject = project(":tf-layer-loader")
+val tfLayerPythonProject = project(":tf-layer-python")
 val tfLayersProject = project(":tf-layers")
 val utilProject = project(":util")
 
@@ -40,6 +41,7 @@ val kotlinProjects = setOf(
     tasksYolov3Project,
     testUtilProject,
     tfLayerLoaderProject,
+    tfLayerPythonProject,
     tfLayersProject,
     utilProject
 )
@@ -52,6 +54,7 @@ val publishedProjects = setOf(
     patternMatchProject,
     tasksYolov3Project,
     tfLayerLoaderProject,
+    tfLayerPythonProject,
     tfLayersProject,
     utilProject
 )
@@ -61,6 +64,7 @@ val pitestProjects = setOf(
     patternMatchProject,
     tasksYolov3Project,
     tfLayerLoaderProject,
+    tfLayerPythonProject,
     tfLayersProject,
     utilProject
 )

--- a/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/UniqueVariableNameGenerator.kt
+++ b/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/UniqueVariableNameGenerator.kt
@@ -1,6 +1,12 @@
 package edu.wpi.axon.dsl
 
+/**
+ * Generates unique variables names (unique to this instance).
+ */
 interface UniqueVariableNameGenerator {
 
+    /**
+     * @return A new unique variable name.
+     */
     fun uniqueVariableName(): String
 }

--- a/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/UniqueVariableNameGenerator.kt
+++ b/dsl-interface/src/main/kotlin/edu/wpi/axon/dsl/UniqueVariableNameGenerator.kt
@@ -1,0 +1,6 @@
+package edu.wpi.axon.dsl
+
+interface UniqueVariableNameGenerator {
+
+    fun uniqueVariableName(): String
+}

--- a/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/TestUtil.kt
+++ b/dsl-test-util/src/main/kotlin/edu/wpi/axon/dsl/TestUtil.kt
@@ -21,3 +21,11 @@ fun Module.alwaysInvalidPathValidator() =
     single<PathValidator> {
         mockk { every { isValidPathName(any()) } returns false }
     }
+
+fun Module.defaultUniqueVariableNameGenerator() =
+    single<UniqueVariableNameGenerator> {
+        object : UniqueVariableNameGenerator {
+            private var count = 1
+            override fun uniqueVariableName() = "var${count++}"
+        }
+    }

--- a/dsl/dsl.gradle.kts
+++ b/dsl/dsl.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     api(project(":tf-layers"))
 
     implementation(project(":util"))
+    implementation(project(":tf-layer-python"))
 
     testImplementation(project(":dsl-test-util"))
 }

--- a/dsl/dsl.gradle.kts
+++ b/dsl/dsl.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 
     api(koin("koin-core"))
     api(project(":dsl-interface"))
+    api(project(":tf-layers"))
 
     implementation(project(":util"))
 

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/DefaultUniqueVariableNameGenerator.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/DefaultUniqueVariableNameGenerator.kt
@@ -1,8 +1,11 @@
 package edu.wpi.axon.dsl
 
+/**
+ * Returns variable names like `var1`, `var2`, etc. with synchronized access.
+ */
 class DefaultUniqueVariableNameGenerator : UniqueVariableNameGenerator {
 
-    override fun uniqueVariableName(): String {
-        TODO("not implemented")
-    }
+    private var count = 0
+
+    override fun uniqueVariableName() = synchronized(this) { "var${count++}" }
 }

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/DefaultUniqueVariableNameGenerator.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/DefaultUniqueVariableNameGenerator.kt
@@ -1,0 +1,8 @@
+package edu.wpi.axon.dsl
+
+class DefaultUniqueVariableNameGenerator : UniqueVariableNameGenerator {
+
+    override fun uniqueVariableName(): String {
+        TODO("not implemented")
+    }
+}

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/KoinModules.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/KoinModules.kt
@@ -12,4 +12,5 @@ fun defaultModule() = module {
     single<VariableNameValidator> { PythonVariableNameValidator() }
     single<PathValidator> { DefaultPathValidator() }
     single<ImportValidator> { DefaultImportValidator() }
+    single<UniqueVariableNameGenerator> { DefaultUniqueVariableNameGenerator() }
 }

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
@@ -1,0 +1,88 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.imports.makeImport
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.tflayers.Activation
+import edu.wpi.axon.tflayers.Layer
+import edu.wpi.axon.util.singleAssign
+
+/**
+ * Adds and removes layers on a new model using a starting model.
+ */
+class ApplyLayerDeltaTask(name: String) : BaseTask(name) {
+
+    /**
+     * The model to take the starting layers from.
+     */
+    var modelInput: Variable by singleAssign()
+
+    /**
+     * The layers to add.
+     */
+    var layersToAdd: List<Layer> by singleAssign()
+
+    /**
+     * The layers to remove.
+     */
+    var layersToRemove: List<Layer> by singleAssign()
+
+    /**
+     * The variable to output the new model to.
+     */
+    var newModelOutput: Variable by singleAssign()
+
+    override val imports: Set<Import> = setOf(
+        makeImport("import tensorflow as tf")
+    )
+
+    override val inputs: Set<Variable>
+        get() = setOf(modelInput)
+
+    override val outputs: Set<Variable>
+        get() = setOf(newModelOutput)
+
+    override val dependencies: Set<Code<*>> = setOf()
+
+    override fun code(): String {
+        val layersToAddName = uniqueVariableNameGenerator.uniqueVariableName()
+        val layersToRemoveName = uniqueVariableNameGenerator.uniqueVariableName()
+        return """
+        |${newModelOutput.name} = tf.keras.Sequential()
+        |$layersToAddName = ${layerConstructors(layersToAdd, layersToAddName.length + 4)}
+        |$layersToRemoveName = ${layerNames(layersToRemove)}
+        |
+        |for layer in ${modelInput.name}.layers:
+        |   if layer.name not in $layersToRemoveName:
+        |       ${newModelOutput.name}.add(layer)
+        """.trimMargin()
+    }
+
+    private fun layerNames(layers: List<Layer>) =
+        layers.joinToString(prefix = "[", separator = ", ", postfix = "]") { """"${it.name}"""" }
+
+    private fun layerConstructors(layers: List<Layer>, indent: Int) =
+        layers.joinToString(prefix = "[", separator = ",\n${" ".repeat(indent)}", postfix = "]") {
+            when (it) {
+                is Layer.Dense -> """tf.keras.layers.Dense(name="${it.name}", """ +
+                    "trainable=${boolToPythonString(it.trainable)}, " +
+                    "units=${it.units}, " +
+                    "activation=${activationConstructor(it.activation)})"
+
+                is Layer.UnknownLayer ->
+                    throw IllegalArgumentException("Cannot construct an unknown layer: $it")
+            }
+        }
+
+    private fun activationConstructor(activation: Activation) = "tf.keras.activations." +
+        when (activation) {
+            is Activation.ReLu -> "relu"
+            is Activation.SoftMax -> "softmax"
+            is Activation.UnknownActivation -> throw IllegalArgumentException(
+                "Cannot construct an unknown activation function: $activation"
+            )
+        }
+
+    private fun boolToPythonString(bool: Boolean): String = if (bool) "True" else "False"
+}

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
@@ -53,8 +53,11 @@ class ApplyLayerDeltaTask(name: String) : BaseTask(name) {
     override fun code(): String {
         val layerOperations = newLayers.map {
             if (it in currentLayers) {
+                // Copy layers that are already in the base model to preserve as much configuration
+                // information as possible
                 LayerOperation.CopyLayer(it)
             } else {
+                // We are forced to make new layers if they aren't in the base model
                 LayerOperation.MakeNewLayer(it)
             }
         }

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
@@ -85,6 +85,7 @@ class ApplyLayerDeltaTask(name: String) : BaseTask(name) {
         }
     }
 
+    // TODO: Split this (and activationConstructor) off into another project
     private fun layerConstructor(layer: Layer) = when (layer) {
         is Layer.Dense -> """tf.keras.layers.Dense(name="${layer.name}", """ +
             "trainable=${boolToPythonString(layer.trainable)}, " +
@@ -104,5 +105,6 @@ class ApplyLayerDeltaTask(name: String) : BaseTask(name) {
             )
         }
 
+    // TODO: Split this off into a common file
     private fun boolToPythonString(bool: Boolean): String = if (bool) "True" else "False"
 }

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/BaseTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/BaseTask.kt
@@ -1,6 +1,7 @@
 package edu.wpi.axon.dsl.task
 
 import arrow.data.Valid
+import edu.wpi.axon.dsl.UniqueVariableNameGenerator
 import edu.wpi.axon.dsl.imports.ImportValidator
 import org.koin.core.KoinComponent
 import org.koin.core.inject
@@ -11,6 +12,8 @@ import org.koin.core.inject
 abstract class BaseTask(override val name: String) : Task, KoinComponent {
 
     private val importValidator: ImportValidator by inject()
+
+    protected val uniqueVariableNameGenerator: UniqueVariableNameGenerator by inject()
 
     override fun isConfiguredCorrectly() = importValidator.validateImports(imports) is Valid &&
         inputs.all { it.isConfiguredCorrectly() } && outputs.all { it.isConfiguredCorrectly() }

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskTest.kt
@@ -1,0 +1,190 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.configuredCorrectly
+import edu.wpi.axon.dsl.defaultUniqueVariableNameGenerator
+import edu.wpi.axon.testutil.KoinTestFixture
+import edu.wpi.axon.tflayers.Activation
+import edu.wpi.axon.tflayers.Layer
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
+
+    @Test
+    fun `no layers to add nor remove`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf()
+            layersToRemove = listOf()
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        task.code() shouldBe """
+            |new_model = tf.keras.Sequential()
+            |var1 = []
+            |var2 = []
+            |
+            |for layer in base_model.layers:
+            |   if layer.name not in var2:
+            |       new_model.add(layer)
+        """.trimMargin()
+    }
+
+    @Test
+    fun `remove one layer`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf()
+            layersToRemove = listOf(Layer.Dense("dense_1", true, 10, Activation.ReLu))
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        task.code() shouldBe """
+            |new_model = tf.keras.Sequential()
+            |var1 = []
+            |var2 = ["dense_1"]
+            |
+            |for layer in base_model.layers:
+            |   if layer.name not in var2:
+            |       new_model.add(layer)
+        """.trimMargin()
+    }
+
+    @Test
+    fun `remove two layers`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf()
+            layersToRemove = listOf(
+                Layer.Dense("dense_1", true, 10, Activation.ReLu),
+                Layer.UnknownLayer("unknown_1", true)
+            )
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        task.code() shouldBe """
+            |new_model = tf.keras.Sequential()
+            |var1 = []
+            |var2 = ["dense_1", "unknown_1"]
+            |
+            |for layer in base_model.layers:
+            |   if layer.name not in var2:
+            |       new_model.add(layer)
+        """.trimMargin()
+    }
+
+    @Test
+    fun `add one layer`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf(Layer.Dense("dense_1", true, 10, Activation.ReLu))
+            layersToRemove = listOf()
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        task.code() shouldBe """
+            |new_model = tf.keras.Sequential()
+            |var1 = [tf.keras.layers.Dense(name="dense_1", trainable=True, units=10, activation=tf.keras.activations.relu)]
+            |var2 = []
+            |
+            |for layer in base_model.layers:
+            |   if layer.name not in var2:
+            |       new_model.add(layer)
+        """.trimMargin()
+    }
+
+    @Test
+    fun `add two layers`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf(
+                Layer.Dense("dense_1", true, 128, Activation.ReLu),
+                Layer.Dense("dense_2", true, 10, Activation.SoftMax)
+            )
+            layersToRemove = listOf()
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        task.code() shouldBe """
+            |new_model = tf.keras.Sequential()
+            |var1 = [tf.keras.layers.Dense(name="dense_1", trainable=True, units=128, activation=tf.keras.activations.relu),
+            |        tf.keras.layers.Dense(name="dense_2", trainable=True, units=10, activation=tf.keras.activations.softmax)]
+            |var2 = []
+            |
+            |for layer in base_model.layers:
+            |   if layer.name not in var2:
+            |       new_model.add(layer)
+        """.trimMargin()
+    }
+
+    @Test
+    fun `add an unknown layer`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf(Layer.UnknownLayer("layer_1", true))
+            layersToRemove = listOf()
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        shouldThrow<IllegalArgumentException> { task.code() }
+    }
+
+    @Test
+    fun `add layer with an unknown activation function`() {
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+            })
+        }
+
+        val task = ApplyLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            layersToAdd = listOf(
+                Layer.Dense("dense_1", true, 128, Activation.UnknownActivation("activation_1"))
+            )
+            layersToRemove = listOf()
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        shouldThrow<IllegalArgumentException> { task.code() }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(":task-property-testing")
 include(":tasks-yolov3")
 include(":test-util")
 include(":tf-layer-loader")
+include(":tf-layer-python")
 include(":tf-layers")
 include(":util")
 

--- a/task-property-testing/src/test/kotlin/edu/wpi/axon/dsl/GeneralTaskConfigurationTest.kt
+++ b/task-property-testing/src/test/kotlin/edu/wpi/axon/dsl/GeneralTaskConfigurationTest.kt
@@ -1,5 +1,6 @@
 package edu.wpi.axon.dsl
 
+import edu.wpi.axon.dsl.task.ApplyLayerDeltaTask
 import edu.wpi.axon.dsl.task.InferenceTask
 import edu.wpi.axon.dsl.task.LoadClassLabels
 import edu.wpi.axon.dsl.task.LoadImageTask
@@ -114,6 +115,10 @@ internal class GeneralTaskConfigurationTest : KoinTestFixture() {
             Arguments.of(
                 { YoloV3PostprocessTask("") },
                 listOf(YoloV3PostprocessTask::input, YoloV3PostprocessTask::output)
+            ),
+            Arguments.of(
+                { ApplyLayerDeltaTask("") },
+                listOf(ApplyLayerDeltaTask::modelInput, ApplyLayerDeltaTask::newModelOutput)
             )
         )
     }

--- a/tf-layer-python/src/main/kotlin/edu/wpi/axon/tflayer/python/LayerToPython.kt
+++ b/tf-layer-python/src/main/kotlin/edu/wpi/axon/tflayer/python/LayerToPython.kt
@@ -1,0 +1,37 @@
+package edu.wpi.axon.tflayer.python
+
+import edu.wpi.axon.tflayers.Activation
+import edu.wpi.axon.tflayers.Layer
+
+/**
+ * Get the Python code for a [layer].
+ *
+ * @param layer The [Layer].
+ * @return The Python code.
+ */
+fun makeNewLayerPython(layer: Layer) = when (layer) {
+    is Layer.Dense -> """tf.keras.layers.Dense(name="${layer.name}", """ +
+        "trainable=${boolToPythonString(layer.trainable)}, " +
+        "units=${layer.units}, " +
+        "activation=${makeNewActivationPython(layer.activation)})"
+
+    is Layer.UnknownLayer ->
+        throw IllegalArgumentException("Cannot construct an unknown layer: $layer")
+}
+
+/**
+ * Get the Python code for an [activation].
+ *
+ * @param activation The [Activation].
+ * @return The Python code.
+ */
+fun makeNewActivationPython(activation: Activation) = "tf.keras.activations." +
+    when (activation) {
+        is Activation.ReLu -> "relu"
+        is Activation.SoftMax -> "softmax"
+        is Activation.UnknownActivation -> throw IllegalArgumentException(
+            "Cannot construct an unknown activation function: $activation"
+        )
+    }
+
+fun boolToPythonString(bool: Boolean): String = if (bool) "True" else "False"

--- a/tf-layer-python/src/test/kotlin/edu/wpi/axon/tflayer/python/ActivationTest.kt
+++ b/tf-layer-python/src/test/kotlin/edu/wpi/axon/tflayer/python/ActivationTest.kt
@@ -1,0 +1,26 @@
+package edu.wpi.axon.tflayer.python
+
+import edu.wpi.axon.tflayers.Activation
+import io.kotlintest.shouldBe
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class ActivationTest {
+
+    @ParameterizedTest
+    @MethodSource("activationSource")
+    fun `test activations`(activation: Activation, expected: String) {
+        makeNewActivationPython(activation) shouldBe expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        @Suppress("unused")
+        fun activationSource() = listOf(
+            Arguments.of(Activation.ReLu, "tf.keras.activations.relu"),
+            Arguments.of(Activation.SoftMax, "tf.keras.activations.softmax")
+        )
+    }
+}

--- a/tf-layer-python/src/test/kotlin/edu/wpi/axon/tflayer/python/LayerTest.kt
+++ b/tf-layer-python/src/test/kotlin/edu/wpi/axon/tflayer/python/LayerTest.kt
@@ -1,0 +1,29 @@
+package edu.wpi.axon.tflayer.python
+
+import edu.wpi.axon.tflayers.Activation
+import edu.wpi.axon.tflayers.Layer
+import io.kotlintest.shouldBe
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class LayerTest {
+
+    @ParameterizedTest
+    @MethodSource("layerSource")
+    fun `test layers`(layer: Layer, expected: String) {
+        makeNewLayerPython(layer) shouldBe expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        @Suppress("unused")
+        fun layerSource() = listOf(
+            Arguments.of(
+                Layer.Dense("name", true, 3, Activation.ReLu),
+                """tf.keras.layers.Dense(name="name", trainable=True, units=3, activation=tf.keras.activations.relu)"""
+            )
+        )
+    }
+}

--- a/tf-layer-python/tf-layer-python.gradle.kts
+++ b/tf-layer-python/tf-layer-python.gradle.kts
@@ -1,0 +1,5 @@
+description = "Python implementations for TF layers."
+
+dependencies {
+    api(project(":tf-layers"))
+}


### PR DESCRIPTION
### Description of the Change

This PR adds a Task that can apply a "layer delta" to a model (creating a new model, not side-effecting an existing model).

### Motivation

We need to support configuration and editing of layers in an existing model.

### Verification Process

Unit tests for the Task.

### Applicable Issues

Closes #25.
