### PR TITLE
Lift the trainable flag into another sealed class type

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTask.kt
@@ -68,21 +68,14 @@ class ApplyLayerDeltaTask(name: String) : BaseTask(name) {
         val innerCurrentLayers = currentLayers.map { it.layer }
 
         return newLayers.map {
-            when (it) {
-                is SealedLayer.MetaLayer.TrainableLayer,
-                is SealedLayer.MetaLayer.UntrainableLayer -> {
-                    // Compare using the inner layer so the trainable status does not matter
-                    if (it.layer in innerCurrentLayers) {
-                        // Copy layers that are already in the base model to preserve as much
-                        // configuration information as possible
-                        LayerOperation.CopyLayer(it)
-                    } else {
-                        // We are forced to make new layers if they aren't in the base model
-                        LayerOperation.MakeNewLayer(it)
-                    }
-                }
-
-                else -> throw IllegalStateException("Must have a SealedLayer.MetaLayer, got: $it")
+            // Compare using the inner layer so the trainable status does not matter
+            if (it.layer in innerCurrentLayers) {
+                // Copy layers that are already in the base model to preserve as much
+                // configuration information as possible
+                LayerOperation.CopyLayer(it)
+            } else {
+                // We are forced to make new layers if they aren't in the base model
+                LayerOperation.MakeNewLayer(it)
             }
         }
     }

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskIntegrationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskIntegrationTest.kt
@@ -1,3 +1,4 @@
+@file:SuppressWarnings("TooManyFunctions", "StringLiteralDuplication", "LargeClass")
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.configuredCorrectly

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskTest.kt
@@ -5,7 +5,8 @@ import edu.wpi.axon.dsl.defaultUniqueVariableNameGenerator
 import edu.wpi.axon.testutil.KoinTestFixture
 import edu.wpi.axon.tflayer.python.LayerToCode
 import edu.wpi.axon.tflayers.Activation
-import edu.wpi.axon.tflayers.Layer
+import edu.wpi.axon.tflayers.SealedLayer
+import edu.wpi.axon.tflayers.trainable
 import io.kotlintest.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -23,7 +24,7 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
             })
         }
 
-        val layer1 = Layer.Dense("dense_1", true, 10, Activation.ReLu)
+        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
 
         val task = ApplyLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
@@ -34,6 +35,7 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([base_model.get_layer("dense_1")])
+            |new_model.get_layer("dense_1").trainable = True
         """.trimMargin()
     }
 
@@ -45,8 +47,8 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
             })
         }
 
-        val layer1 = Layer.Dense("dense_1", true, 10, Activation.ReLu)
-        val layer2 = Layer.UnknownLayer("unknown_1", true)
+        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
+        val layer2 = SealedLayer.UnknownLayer("unknown_1").trainable()
 
         val task = ApplyLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
@@ -60,6 +62,8 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
             |    base_model.get_layer("dense_1"),
             |    base_model.get_layer("unknown_1")
             |])
+            |new_model.get_layer("dense_1").trainable = True
+            |new_model.get_layer("unknown_1").trainable = True
         """.trimMargin()
     }
 
@@ -73,13 +77,14 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
         val task = ApplyLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
-            currentLayers = listOf(Layer.Dense("dense_1", true, 10, Activation.ReLu))
+            currentLayers = listOf(SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable())
             newLayers = listOf()
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([])
+            |
         """.trimMargin()
     }
 
@@ -94,8 +99,8 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
         val task = ApplyLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = listOf(
-                Layer.Dense("dense_1", true, 10, Activation.ReLu),
-                Layer.UnknownLayer("unknown_1", true)
+                SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable(),
+                SealedLayer.UnknownLayer("unknown_1").trainable()
             )
             newLayers = listOf()
             newModelOutput = configuredCorrectly("new_model")
@@ -103,12 +108,13 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([])
+            |
         """.trimMargin()
     }
 
     @Test
     fun `add one layer`() {
-        val layer1 = Layer.Dense("dense_1", true, 10, Activation.ReLu)
+        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
 
         startKoin {
             modules(module {
@@ -130,13 +136,14 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([layer1])
+            |new_model.get_layer("dense_1").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `add two layers`() {
-        val layer1 = Layer.Dense("dense_1", true, 128, Activation.ReLu)
-        val layer2 = Layer.Dense("dense_2", true, 10, Activation.SoftMax)
+        val layer1 = SealedLayer.Dense("dense_1", 128, Activation.ReLu).trainable()
+        val layer2 = SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
 
         startKoin {
             modules(module {
@@ -162,14 +169,16 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
             |    layer1,
             |    layer2
             |])
+            |new_model.get_layer("dense_1").trainable = True
+            |new_model.get_layer("dense_2").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `remove the first layer and replace the second and swap them`() {
-        val layer1 = Layer.UnknownLayer("unknown_3", true)
-        val layer2Old = Layer.Dense("dense_2", true, 10, Activation.SoftMax)
-        val layer2New = Layer.Dense("dense_2", true, 3, Activation.SoftMax)
+        val layer1 = SealedLayer.UnknownLayer("unknown_3").trainable()
+        val layer2Old = SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
+        val layer2New = SealedLayer.Dense("dense_2", 3, Activation.SoftMax).trainable()
 
         startKoin {
             modules(module {
@@ -194,6 +203,8 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
             |    layer2New,
             |    base_model.get_layer("unknown_3")
             |])
+            |new_model.get_layer("dense_2").trainable = True
+            |new_model.get_layer("unknown_3").trainable = True
         """.trimMargin()
     }
 
@@ -205,7 +216,7 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
             })
         }
 
-        val layer1 = Layer.UnknownLayer("unknown_1", true)
+        val layer1 = SealedLayer.UnknownLayer("unknown_1").trainable()
 
         val task = ApplyLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
@@ -216,12 +227,14 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([base_model.get_layer("unknown_1")])
+            |new_model.get_layer("unknown_1").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `copy a layer with an unknown activation function`() {
-        val layer1 = Layer.Dense("dense_1", true, 10, Activation.UnknownActivation("activation_1"))
+        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.UnknownActivation("activation_1"))
+            .trainable()
 
         startKoin {
             modules(module {
@@ -238,6 +251,7 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([base_model.get_layer("dense_1")])
+            |new_model.get_layer("dense_1").trainable = True
         """.trimMargin()
     }
 }

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaTaskTest.kt
@@ -1,3 +1,4 @@
+@file:SuppressWarnings("TooManyFunctions", "StringLiteralDuplication", "LargeClass")
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.configuredCorrectly

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5.kt
@@ -5,6 +5,7 @@ import com.beust.klaxon.JsonObject
 import com.beust.klaxon.Parser
 import edu.wpi.axon.tflayers.Activation
 import edu.wpi.axon.tflayers.Layer
+import edu.wpi.axon.tflayers.SealedLayer
 import io.jhdf.HdfFile
 import java.io.File
 
@@ -35,17 +36,28 @@ class LoadLayersFromHDF5 {
         }
     }
 
+    private fun parseMetaLayer(name: String, json: JsonObject): SealedLayer.MetaLayer =
+        when (json["trainable"] as Boolean) {
+            true -> SealedLayer.MetaLayer.TrainableLayer(
+                json["name"] as String,
+                parseLayer(name, json)
+            )
+
+            false -> SealedLayer.MetaLayer.UntrainableLayer(
+                json["name"] as String,
+                parseLayer(name, json)
+            )
+        }
+
     private fun parseLayer(name: String, json: JsonObject): Layer = when (name) {
-        "Dense" -> Layer.Dense(
+        "Dense" -> SealedLayer.Dense(
             json["name"] as String,
-            json["trainable"] as Boolean,
             json["units"] as Int,
             parseActivation(json)
         )
 
-        else -> Layer.UnknownLayer(
-            json["name"] as String,
-            json["trainable"] as Boolean
+        else -> SealedLayer.UnknownLayer(
+            json["name"] as String
         )
     }
 

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5.kt
@@ -31,7 +31,7 @@ class LoadLayersFromHDF5 {
             return layers.map {
                 val className = it["class_name"] as String
                 val layerData = it["config"] as JsonObject
-                parseLayer(className, layerData)
+                parseMetaLayer(className, layerData)
             }
         }
     }

--- a/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5Test.kt
+++ b/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5Test.kt
@@ -1,7 +1,7 @@
 package edu.wpi.axon.tflayerloader
 
 import edu.wpi.axon.tflayers.Activation
-import edu.wpi.axon.tflayers.Layer
+import edu.wpi.axon.tflayers.SealedLayer
 import io.kotlintest.matchers.equality.shouldBeEqualToUsingFields
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -121,14 +121,14 @@ internal class LoadLayersFromHDF5Test {
             File(LoadLayersFromHDF5Test::class.java.getResource("saved_tf_model.h5").toURI())
         ).shouldBeEqualToUsingFields(
             setOf(
-                Layer.UnknownLayer("conv2d_16", true),
-                Layer.UnknownLayer("conv2d_17", true),
-                Layer.UnknownLayer("max_pooling2d_8", true),
-                Layer.UnknownLayer("dropout_19", true),
-                Layer.UnknownLayer("flatten_8", true),
-                Layer.Dense("dense_22", true, 128, Activation.ReLu),
-                Layer.UnknownLayer("dropout_20", true),
-                Layer.Dense("dense_23", true, 10, Activation.SoftMax)
+                SealedLayer.UnknownLayer("conv2d_16"),
+                SealedLayer.UnknownLayer("conv2d_17"),
+                SealedLayer.UnknownLayer("max_pooling2d_8"),
+                SealedLayer.UnknownLayer("dropout_19"),
+                SealedLayer.UnknownLayer("flatten_8"),
+                SealedLayer.Dense("dense_22", 128, Activation.ReLu),
+                SealedLayer.UnknownLayer("dropout_20"),
+                SealedLayer.Dense("dense_23", 10, Activation.SoftMax)
             )
         )
     }

--- a/tf-layer-python/src/main/kotlin/edu/wpi/axon/tflayer/python/DefaultLayerToPythonCode.kt
+++ b/tf-layer-python/src/main/kotlin/edu/wpi/axon/tflayer/python/DefaultLayerToPythonCode.kt
@@ -2,20 +2,21 @@ package edu.wpi.axon.tflayer.python
 
 import edu.wpi.axon.tflayers.Activation
 import edu.wpi.axon.tflayers.Layer
+import edu.wpi.axon.tflayers.SealedLayer
 
 /**
  * An implementation of [LayerToCode] for Python.
  */
 class DefaultLayerToPythonCode : LayerToCode {
 
-    override fun makeNewLayer(layer: Layer) = when (layer) {
-        is Layer.Dense -> """tf.keras.layers.Dense(name="${layer.name}", """ +
-            "trainable=${boolToPythonString(layer.trainable)}, " +
+    override fun makeNewLayer(layer: Layer): String = when (layer) {
+        is SealedLayer.MetaLayer -> makeNewLayer(layer.layer)
+
+        is SealedLayer.Dense -> """tf.keras.layers.Dense(name="${layer.name}", """ +
             "units=${layer.units}, " +
             "activation=${makeNewActivation(layer.activation)})"
 
-        is Layer.UnknownLayer ->
-            throw IllegalArgumentException("Cannot construct an unknown layer: $layer")
+        else -> throw IllegalArgumentException("Cannot construct an unknown layer: $layer")
     }
 
     override fun makeNewActivation(activation: Activation) = "tf.keras.activations." +

--- a/tf-layer-python/src/test/kotlin/edu/wpi/axon/tflayer/python/DefaultLayerToPythonCodeTest.kt
+++ b/tf-layer-python/src/test/kotlin/edu/wpi/axon/tflayer/python/DefaultLayerToPythonCodeTest.kt
@@ -2,6 +2,8 @@ package edu.wpi.axon.tflayer.python
 
 import edu.wpi.axon.tflayers.Activation
 import edu.wpi.axon.tflayers.Layer
+import edu.wpi.axon.tflayers.SealedLayer
+import edu.wpi.axon.tflayers.trainable
 import io.kotlintest.shouldBe
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -29,8 +31,12 @@ internal class DefaultLayerToPythonCodeTest {
         @Suppress("unused")
         fun layerSource() = listOf(
             Arguments.of(
-                Layer.Dense("name", true, 3, Activation.ReLu),
-                """tf.keras.layers.Dense(name="name", trainable=True, units=3, activation=tf.keras.activations.relu)"""
+                SealedLayer.Dense("name", 3, Activation.ReLu),
+                """tf.keras.layers.Dense(name="name", units=3, activation=tf.keras.activations.relu)"""
+            ),
+            Arguments.of(
+                SealedLayer.Dense("name", 3, Activation.ReLu).trainable(),
+                """tf.keras.layers.Dense(name="name", units=3, activation=tf.keras.activations.relu)"""
             )
         )
 

--- a/tf-layers/src/main/kotlin/edu/wpi/axon/tflayers/Layer.kt
+++ b/tf-layers/src/main/kotlin/edu/wpi/axon/tflayers/Layer.kt
@@ -1,45 +1,12 @@
 package edu.wpi.axon.tflayers
 
+/**
+ * A TensorFlow layer.
+ */
 interface Layer {
 
+    /**
+     * The unique name of this layer.
+     */
     val name: String
 }
-
-sealed class SealedLayer : Layer {
-
-    sealed class MetaLayer(open val layer: Layer) : SealedLayer() {
-
-        data class TrainableLayer(
-            override val name: String,
-            override val layer: Layer
-        ) : MetaLayer(layer), Layer by layer
-
-        data class UntrainableLayer(
-            override val name: String,
-            override val layer: Layer
-        ) : MetaLayer(layer), Layer by layer
-    }
-
-    /**
-     * A placeholder layer for a layer that Axon does not understand.
-     */
-    data class UnknownLayer(
-        override val name: String
-    ) : SealedLayer()
-
-    /**
-     * A Dense layer.
-     *
-     * @param units The number of neurons.
-     * @param activation The [Activation] function.
-     */
-    data class Dense(
-        override val name: String,
-        val units: Int,
-        val activation: Activation
-    ) : SealedLayer()
-}
-
-fun Layer.trainable() = SealedLayer.MetaLayer.TrainableLayer(name, this)
-
-fun Layer.untrainable() = SealedLayer.MetaLayer.UntrainableLayer(name, this)

--- a/tf-layers/src/main/kotlin/edu/wpi/axon/tflayers/SealedLayer.kt
+++ b/tf-layers/src/main/kotlin/edu/wpi/axon/tflayers/SealedLayer.kt
@@ -1,0 +1,62 @@
+package edu.wpi.axon.tflayers
+
+/**
+ * A sealed [Layer] implementation.
+ */
+sealed class SealedLayer : Layer {
+
+    /**
+     * A sealed [Layer] which delegates to another [layer].
+     */
+    sealed class MetaLayer(open val layer: Layer) : SealedLayer() {
+
+        /**
+         * A [Layer] which is trainable.
+         */
+        data class TrainableLayer(
+            override val name: String,
+            override val layer: Layer
+        ) : MetaLayer(layer), Layer by layer
+
+        /**
+         * A [Layer] which is untrainable.
+         */
+        data class UntrainableLayer(
+            override val name: String,
+            override val layer: Layer
+        ) : MetaLayer(layer), Layer by layer
+    }
+
+    /**
+     * A placeholder layer for a layer that Axon does not understand.
+     */
+    data class UnknownLayer(
+        override val name: String
+    ) : SealedLayer()
+
+    /**
+     * A Dense layer.
+     *
+     * @param units The number of neurons.
+     * @param activation The [Activation] function.
+     */
+    data class Dense(
+        override val name: String,
+        val units: Int,
+        val activation: Activation
+    ) : SealedLayer()
+}
+
+/**
+ * Creates a new [SealedLayer.MetaLayer.TrainableLayer].
+ *
+ * @receiver The [Layer] to wrap.
+ */
+fun Layer.trainable() = SealedLayer.MetaLayer.TrainableLayer(name, this)
+
+/**
+ * Creates a new [SealedLayer.MetaLayer.UntrainableLayer].
+ *
+ * @receiver The [Layer] to wrap.
+ */
+fun Layer.untrainable() = SealedLayer.MetaLayer.UntrainableLayer(name, this)


### PR DESCRIPTION
### Description of the Change

This PR lifts the trainable flag from Layer into MetaLayer.

### Motivation

We need to compare layers regardless of whether they are trainable and also be able to set the trainable flag for each layer arbitrarily. Lifting the trainable flag from the old Layer type and adding a MetaLayer sealed type is the simplest way to handle both of these cases.

### Verification Process

Added a test for #33.

### Applicable Issues

Closes #33.
