### PR TITLE
Add LoadExampleDatasetTask

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/KoinModules.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/KoinModules.kt
@@ -6,11 +6,13 @@ import edu.wpi.axon.dsl.validator.path.DefaultPathValidator
 import edu.wpi.axon.dsl.validator.path.PathValidator
 import edu.wpi.axon.dsl.validator.variablename.PythonVariableNameValidator
 import edu.wpi.axon.dsl.validator.variablename.VariableNameValidator
+import edu.wpi.axon.tfdata.code.DatasetToCode
+import edu.wpi.axon.tfdata.code.DefaultDatasetToCode
 import edu.wpi.axon.tfdata.code.layer.DefaultLayerToCode
-import edu.wpi.axon.tfdata.code.loss.DefaultLossToCode
-import edu.wpi.axon.tfdata.code.optimizer.DefaultOptimizerToCode
 import edu.wpi.axon.tfdata.code.layer.LayerToCode
+import edu.wpi.axon.tfdata.code.loss.DefaultLossToCode
 import edu.wpi.axon.tfdata.code.loss.LossToCode
+import edu.wpi.axon.tfdata.code.optimizer.DefaultOptimizerToCode
 import edu.wpi.axon.tfdata.code.optimizer.OptimizerToCode
 import org.koin.dsl.module
 
@@ -22,4 +24,5 @@ fun defaultModule() = module {
     single<LayerToCode> { DefaultLayerToCode() }
     single<OptimizerToCode> { DefaultOptimizerToCode() }
     single<LossToCode> { DefaultLossToCode() }
+    single<DatasetToCode> { DefaultDatasetToCode() }
 }

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTask.kt
@@ -1,0 +1,47 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.imports.makeImport
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.tfdata.Dataset
+import edu.wpi.axon.tfdata.code.DatasetToCode
+import edu.wpi.axon.util.singleAssign
+import org.koin.core.inject
+
+/**
+ * Loads one of the example datasets.
+ */
+class LoadExampleDatasetTask(name: String) : BaseTask(name) {
+
+    /**
+     * The dataset to load.
+     */
+    var dataset: Dataset by singleAssign()
+
+    var xTrain: Variable by singleAssign()
+    var yTrain: Variable by singleAssign()
+    var xTest: Variable by singleAssign()
+    var yTest: Variable by singleAssign()
+
+    private val datasetToCode: DatasetToCode by inject()
+
+    override val imports: Set<Import> = setOf(
+        makeImport("import tensorflow as tf")
+    )
+
+    override val inputs: Set<Variable> = setOf()
+
+    override val outputs: Set<Variable>
+        get() = setOf(xTrain, yTrain, xTest, yTest)
+
+    override val dependencies: Set<Code<*>>
+        get() = setOf()
+
+    override fun code(): String {
+        val output = """(${xTrain.name}, ${yTrain.name}), (${xTest.name}, ${yTest.name})"""
+        return """
+            |$output = ${datasetToCode.datasetToCode(dataset)}.load_data()
+        """.trimMargin()
+    }
+}

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTask.kt
@@ -19,10 +19,25 @@ class LoadExampleDatasetTask(name: String) : BaseTask(name) {
      */
     var dataset: Dataset by singleAssign()
 
-    var xTrain: Variable by singleAssign()
-    var yTrain: Variable by singleAssign()
-    var xTest: Variable by singleAssign()
-    var yTest: Variable by singleAssign()
+    /**
+     * The input data for training.
+     */
+    var xTrainOutput: Variable by singleAssign()
+
+    /**
+     * The target data for training.
+     */
+    var yTrainOutput: Variable by singleAssign()
+
+    /**
+     * The input data for validation.
+     */
+    var xTestOutput: Variable by singleAssign()
+
+    /**
+     * The target data for validation.
+     */
+    var yTestOutput: Variable by singleAssign()
 
     private val datasetToCode: DatasetToCode by inject()
 
@@ -33,13 +48,14 @@ class LoadExampleDatasetTask(name: String) : BaseTask(name) {
     override val inputs: Set<Variable> = setOf()
 
     override val outputs: Set<Variable>
-        get() = setOf(xTrain, yTrain, xTest, yTest)
+        get() = setOf(xTrainOutput, yTrainOutput, xTestOutput, yTestOutput)
 
     override val dependencies: Set<Code<*>>
         get() = setOf()
 
     override fun code(): String {
-        val output = """(${xTrain.name}, ${yTrain.name}), (${xTest.name}, ${yTest.name})"""
+        val output = "(${xTrainOutput.name}, ${yTrainOutput.name}), " +
+            "(${xTestOutput.name}, ${yTestOutput.name})"
         return """
             |$output = ${datasetToCode.datasetToCode(dataset)}.load_data()
         """.trimMargin()

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskConfigurationTest.kt
@@ -6,9 +6,9 @@ internal class LoadExampleDatasetTaskConfigurationTest :
     TaskConfigurationTestFixture<LoadExampleDatasetTask>(
         LoadExampleDatasetTask::class,
         listOf(
-            LoadExampleDatasetTask::xTrain,
-            LoadExampleDatasetTask::yTrain,
-            LoadExampleDatasetTask::xTest,
-            LoadExampleDatasetTask::yTest
+            LoadExampleDatasetTask::xTrainOutput,
+            LoadExampleDatasetTask::yTrainOutput,
+            LoadExampleDatasetTask::xTestOutput,
+            LoadExampleDatasetTask::yTestOutput
         )
     )

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskConfigurationTest.kt
@@ -1,0 +1,14 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.TaskConfigurationTestFixture
+
+internal class LoadExampleDatasetTaskConfigurationTest :
+    TaskConfigurationTestFixture<LoadExampleDatasetTask>(
+        LoadExampleDatasetTask::class,
+        listOf(
+            LoadExampleDatasetTask::xTrain,
+            LoadExampleDatasetTask::yTrain,
+            LoadExampleDatasetTask::xTest,
+            LoadExampleDatasetTask::yTest
+        )
+    )

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskTest.kt
@@ -1,0 +1,46 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.configuredCorrectly
+import edu.wpi.axon.testutil.KoinTestFixture
+import edu.wpi.axon.tfdata.Dataset
+import edu.wpi.axon.tfdata.code.DatasetToCode
+import io.kotlintest.shouldBe
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+internal class LoadExampleDatasetTaskTest : KoinTestFixture() {
+
+    @Test
+    fun `test code gen`() {
+        val mockDataset = mockk<Dataset> { every { name } returns "dataset_name" }
+        val mockDatasetToCode = mockk<DatasetToCode> {
+            every { datasetToCode(mockDataset) } returns "dataset_code"
+        }
+
+        startKoin {
+            modules(module {
+                single { mockDatasetToCode }
+            })
+        }
+
+        val task = LoadExampleDatasetTask("task").apply {
+            dataset = mockDataset
+            xTrain = configuredCorrectly("xTrain")
+            yTrain = configuredCorrectly("yTrain")
+            xTest = configuredCorrectly("xTest")
+            yTest = configuredCorrectly("yTest")
+        }
+
+        task.code() shouldBe """
+            |(xTrain, yTrain), (xTest, yTest) = dataset_code.load_data()
+        """.trimMargin()
+
+        verify { mockDatasetToCode.datasetToCode(mockDataset) }
+        confirmVerified(mockDatasetToCode)
+    }
+}

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadExampleDatasetTaskTest.kt
@@ -30,10 +30,10 @@ internal class LoadExampleDatasetTaskTest : KoinTestFixture() {
 
         val task = LoadExampleDatasetTask("task").apply {
             dataset = mockDataset
-            xTrain = configuredCorrectly("xTrain")
-            yTrain = configuredCorrectly("yTrain")
-            xTest = configuredCorrectly("xTest")
-            yTest = configuredCorrectly("yTest")
+            xTrainOutput = configuredCorrectly("xTrain")
+            yTrainOutput = configuredCorrectly("yTrain")
+            xTestOutput = configuredCorrectly("xTest")
+            yTestOutput = configuredCorrectly("yTest")
         }
 
         task.code() shouldBe """

--- a/tf-data-code/src/main/kotlin/edu/wpi/axon/tfdata/code/DatasetToCode.kt
+++ b/tf-data-code/src/main/kotlin/edu/wpi/axon/tfdata/code/DatasetToCode.kt
@@ -1,0 +1,14 @@
+package edu.wpi.axon.tfdata.code
+
+import edu.wpi.axon.tfdata.Dataset
+
+interface DatasetToCode {
+
+    /**
+     * Get the code to make a new instance of a [dataset].
+     *
+     * @param dataset The [Dataset].
+     * @return The code to make a new instance of the [dataset].
+     */
+    fun datasetToCode(dataset: Dataset): String
+}

--- a/tf-data-code/src/main/kotlin/edu/wpi/axon/tfdata/code/DefaultDatasetToCode.kt
+++ b/tf-data-code/src/main/kotlin/edu/wpi/axon/tfdata/code/DefaultDatasetToCode.kt
@@ -1,0 +1,8 @@
+package edu.wpi.axon.tfdata.code
+
+import edu.wpi.axon.tfdata.Dataset
+
+class DefaultDatasetToCode : DatasetToCode {
+
+    override fun datasetToCode(dataset: Dataset) = "tf.keras.datasets.${dataset.name}"
+}

--- a/tf-data-code/src/test/kotlin/edu/wpi/axon/tfdata/code/DefaultDatasetToCodeTest.kt
+++ b/tf-data-code/src/test/kotlin/edu/wpi/axon/tfdata/code/DefaultDatasetToCodeTest.kt
@@ -1,0 +1,18 @@
+package edu.wpi.axon.tfdata.code
+
+import edu.wpi.axon.tfdata.Dataset
+import io.kotlintest.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+internal class DefaultDatasetToCodeTest {
+
+    private val datasetToCode = DefaultDatasetToCode()
+
+    @Test
+    fun `test code gen`() {
+        val dataset = mockk<Dataset> { every { name } returns "dataset_name" }
+        datasetToCode.datasetToCode(dataset) shouldBe "tf.keras.datasets.dataset_name"
+    }
+}

--- a/tf-data-code/tf-data-code.gradle.kts
+++ b/tf-data-code/tf-data-code.gradle.kts
@@ -2,4 +2,6 @@ description = "Python implementations for TF layers."
 
 dependencies {
     api(project(":tf-data"))
+
+    testImplementation(project(":test-util"))
 }

--- a/tf-data/src/main/kotlin/edu/wpi/axon/tfdata/Dataset.kt
+++ b/tf-data/src/main/kotlin/edu/wpi/axon/tfdata/Dataset.kt
@@ -1,0 +1,11 @@
+package edu.wpi.axon.tfdata
+
+sealed class Dataset(val name: String) {
+    object BostonHousing : Dataset("boston_housing")
+    object Cifar10 : Dataset("cifar10")
+    object Cifar100 : Dataset("cifar100")
+    object FashionMnist : Dataset("fashion_mnist")
+    object IMDB : Dataset("imdb")
+    object Mnist : Dataset("mnist")
+    object Reuters : Dataset("reuters")
+}

--- a/tf-data/src/test/kotlin/edu/wpi/axon/tfdata/DatasetTest.kt
+++ b/tf-data/src/test/kotlin/edu/wpi/axon/tfdata/DatasetTest.kt
@@ -1,0 +1,30 @@
+package edu.wpi.axon.tfdata
+
+import io.kotlintest.shouldBe
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class DatasetTest {
+
+    @ParameterizedTest
+    @MethodSource("datasetSource")
+    fun `test dataset names`(dataset: Dataset, expected: String) {
+        dataset.name shouldBe expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        @Suppress("unused")
+        fun datasetSource() = listOf(
+            Arguments.of(Dataset.BostonHousing, "boston_housing"),
+            Arguments.of(Dataset.Cifar10, "cifar10"),
+            Arguments.of(Dataset.Cifar100, "cifar100"),
+            Arguments.of(Dataset.FashionMnist, "fashion_mnist"),
+            Arguments.of(Dataset.IMDB, "imdb"),
+            Arguments.of(Dataset.Mnist, "mnist"),
+            Arguments.of(Dataset.Reuters, "reuters")
+        )
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds a task that can load the example TF datasets.

### Motivation

This is an easy starting place to load data to make a transfer learning example.

### Verification Process

Unit tests for the new behavior.

### Applicable Issues

Closes #42.
