### PR TITLE
Add LoadModelTask

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadModelTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/LoadModelTask.kt
@@ -1,0 +1,46 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.imports.makeImport
+import edu.wpi.axon.dsl.validator.path.PathValidator
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.util.singleAssign
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+/**
+ * Loads a model from an HDF5 file.
+ */
+class LoadModelTask(name: String) : BaseTask(name), KoinComponent {
+
+    /**
+     * The file path to load the model from.
+     */
+    var modelPath: String by singleAssign()
+
+    /**
+     * The output the model will be stored in.
+     */
+    var modelOutput: Variable by singleAssign()
+
+    /**
+     * Validates the [modelPath].
+     */
+    private val pathValidator: PathValidator by inject()
+
+    override val imports = setOf(makeImport("import tensorflow as tf"))
+
+    override val inputs: Set<Variable> = emptySet()
+
+    override val outputs: Set<Variable>
+        get() = setOf(modelOutput)
+
+    override val dependencies: Set<Code<*>> = emptySet()
+
+    override fun isConfiguredCorrectly() = pathValidator.isValidPathName(modelPath) &&
+        super.isConfiguredCorrectly()
+
+    override fun code() = """
+        |${modelOutput.name} = tf.keras.models.load_model("$modelPath")
+    """.trimMargin()
+}

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadModelTaskConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadModelTaskConfigurationTest.kt
@@ -1,0 +1,10 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.TaskConfigurationTestFixture
+
+internal class LoadModelTaskConfigurationTest : TaskConfigurationTestFixture<LoadModelTask>(
+    { LoadModelTask("").apply { modelPath = "" } },
+    listOf(
+        LoadModelTask::modelOutput
+    )
+)

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadModelTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/LoadModelTaskTest.kt
@@ -1,0 +1,30 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.alwaysValidPathValidator
+import edu.wpi.axon.dsl.configuredCorrectly
+import edu.wpi.axon.testutil.KoinTestFixture
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+internal class LoadModelTaskTest : KoinTestFixture() {
+
+    @Test
+    fun `test code gen`() {
+        startKoin {
+            modules(module {
+                alwaysValidPathValidator()
+            })
+        }
+
+        val task = LoadModelTask("task").apply {
+            modelPath = "model.h5"
+            modelOutput = configuredCorrectly("output")
+        }
+
+        task.code() shouldBe """
+            |output = tf.keras.models.load_model("model.h5")
+        """.trimMargin()
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds a task that can load a model from an hdf5 file.

### Motivation

This is how we will load all the models.

### Verification Process

Unit tests for the new behavior.

### Applicable Issues

Closes #44.
