### PR TITLE
Add ReshapeAndScaleTask

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ReshapeAndScaleTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ReshapeAndScaleTask.kt
@@ -1,0 +1,50 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.util.singleAssign
+
+/**
+ * Reshapes and scales numpy arrays.
+ */
+class ReshapeAndScaleTask(name: String) : BaseTask(name) {
+
+    /**
+     * The input.
+     */
+    var input: Variable by singleAssign()
+
+    /**
+     * The output.
+     */
+    var output: Variable by singleAssign()
+
+    /**
+     * The arguments to reshape.
+     */
+    var reshapeArgs: List<Number> by singleAssign()
+
+    /**
+     * The number to scale each element by. Set to `null` to not scale.
+     */
+    var scale: Number? by singleAssign()
+
+    override val imports: Set<Import> = setOf()
+
+    override val inputs: Set<Variable>
+        get() = setOf(input)
+
+    override val outputs: Set<Variable>
+        get() = setOf(output)
+
+    override val dependencies: MutableSet<Code<*>> = mutableSetOf()
+
+    override fun code(): String {
+        val reshaped = "${output.name} = ${input.name}.reshape(${reshapeArgs.joinToString()})"
+        return when (scale) {
+            null -> reshaped
+            else -> "$reshaped / $scale"
+        }
+    }
+}

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ReshapeAndScaleTaskConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ReshapeAndScaleTaskConfigurationTest.kt
@@ -1,0 +1,17 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.TaskConfigurationTestFixture
+
+internal class ReshapeAndScaleTaskConfigurationTest :
+    TaskConfigurationTestFixture<ReshapeAndScaleTask>(
+        {
+            ReshapeAndScaleTask("").apply {
+                reshapeArgs = listOf()
+                scale = null
+            }
+        },
+        listOf(
+            ReshapeAndScaleTask::input,
+            ReshapeAndScaleTask::output
+        )
+    )

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ReshapeAndScaleTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ReshapeAndScaleTaskTest.kt
@@ -1,0 +1,42 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.configuredCorrectly
+import edu.wpi.axon.testutil.KoinTestFixture
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+
+internal class ReshapeAndScaleTaskTest : KoinTestFixture() {
+
+    @Test
+    fun `test with no scale`() {
+        startKoin { }
+
+        val task = ReshapeAndScaleTask("").apply {
+            input = configuredCorrectly("input")
+            output = configuredCorrectly("output")
+            reshapeArgs = listOf(-1, 28, 28, 1)
+            scale = null
+        }
+
+        task.code() shouldBe """
+            |output = input.reshape(-1, 28, 28, 1)
+        """.trimMargin()
+    }
+
+    @Test
+    fun `test with scale`() {
+        startKoin { }
+
+        val task = ReshapeAndScaleTask("").apply {
+            input = configuredCorrectly("input")
+            output = configuredCorrectly("output")
+            reshapeArgs = listOf(-1, 28, 28, 1)
+            scale = 255
+        }
+
+        task.code() shouldBe """
+            |output = input.reshape(-1, 28, 28, 1) / 255
+        """.trimMargin()
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds a task that can reshape and scale numpy arrays.

### Motivation

This is sometimes needed for preprocessing data before training.

### Verification Process

Unit tests for new behavior.

### Applicable Issues

Closes #46.
