### PR TITLE
Aggregate Jacoco reports

### DIFF
--- a/axon.gradle.kts
+++ b/axon.gradle.kts
@@ -340,6 +340,28 @@ configure(kotlinProjects) {
     }
 }
 
+val jacocoRootReport by tasks.creating(JacocoReport::class) {
+    group = "verification"
+    dependsOn(tasks.withType(JacocoReport::class) - this)
+
+    val allSrcDirs = subprojects.map { it.sourceSets.main.get().allSource.srcDirs }
+    additionalSourceDirs.setFrom(allSrcDirs)
+    sourceDirectories.setFrom(allSrcDirs)
+    classDirectories.setFrom(subprojects.map { it.sourceSets.main.get().output })
+    executionData.setFrom((subprojects - listOf(
+        dslTestUtilProject,
+        loggingProject,
+        testUtilProject,
+        utilProject
+    )).flatMap { it.tasks.withType(JacocoReport::class).map { it.executionData } })
+
+    reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = false
+    }
+}
+
 configure(pitestProjects) {
     apply {
         plugin("info.solidsoft.pitest")

--- a/axon.gradle.kts
+++ b/axon.gradle.kts
@@ -342,7 +342,7 @@ configure(kotlinProjects) {
 
 val jacocoRootReport by tasks.creating(JacocoReport::class) {
     group = "verification"
-    dependsOn(tasks.withType(JacocoReport::class) - this)
+    dependsOn(subprojects.flatMap { it.tasks.withType(JacocoReport::class) } - this)
 
     val allSrcDirs = subprojects.map { it.sourceSets.main.get().allSource.srcDirs }
     additionalSourceDirs.setFrom(allSrcDirs)

--- a/axon.gradle.kts
+++ b/axon.gradle.kts
@@ -348,12 +348,9 @@ val jacocoRootReport by tasks.creating(JacocoReport::class) {
     additionalSourceDirs.setFrom(allSrcDirs)
     sourceDirectories.setFrom(allSrcDirs)
     classDirectories.setFrom(subprojects.map { it.sourceSets.main.get().output })
-    executionData.setFrom((subprojects - listOf(
-        dslTestUtilProject,
-        loggingProject,
-        testUtilProject,
-        utilProject
-    )).flatMap { it.tasks.withType(JacocoReport::class).map { it.executionData } })
+    executionData.setFrom(subprojects.filter {
+        File("${it.buildDir}/jacoco/test.exec").exists()
+    }.flatMap { it.tasks.withType(JacocoReport::class).map { it.executionData } })
 
     reports {
         html.isEnabled = true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,23 @@ stages:
             jdkArchitectureOption: 'x64'
             publishJUnitResults: true
             testResultsFiles: '**/TEST-*.xml'
-            tasks: 'check jacocoRootReport'
+            tasks: 'check'
 
-        - bash: bash <(curl -s https://codecov.io/bash) -f "build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml" || echo 'Codecov failed to upload'
+        - task: Gradle@2
+          displayName: 'Check'
+          inputs:
+            workingDirectory: ''
+            gradleWrapperFile: 'gradlew'
+            gradleOptions: '-Xmx3072m'
+            options: '--stacktrace -PlogTests -Pheadless'
+            javaHomeOption: 'JDKVersion'
+            jdkVersionOption: '1.11'
+            jdkArchitectureOption: 'x64'
+            publishJUnitResults: true
+            testResultsFiles: '**/TEST-*.xml'
+            tasks: 'jacocoRootReport'
+
+        - bash: bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
           displayName: 'CodeCov'
           workingDirectory: ''
           env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,21 @@ stages:
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
-            tasks: 'check jacocoRootReport'
+            tasks: 'check'
+
+        - task: Gradle@2
+          displayName: 'Check'
+          inputs:
+            workingDirectory: ''
+            gradleWrapperFile: 'gradlew'
+            gradleOptions: '-Xmx3072m'
+            options: '--stacktrace -PlogTests -Pheadless'
+            javaHomeOption: 'JDKVersion'
+            jdkVersionOption: '1.11'
+            jdkArchitectureOption: 'x64'
+            publishJUnitResults: true
+            testResultsFiles: '**/TEST-*.xml'
+            tasks: 'jacocoRootReport'
 
     - job: Windows
 
@@ -85,4 +99,18 @@ stages:
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
-            tasks: 'check jacocoRootReport'
+            tasks: 'check'
+
+        - task: Gradle@2
+          displayName: 'Check'
+          inputs:
+            workingDirectory: ''
+            gradleWrapperFile: 'gradlew'
+            gradleOptions: '-Xmx3072m'
+            options: '--stacktrace -PlogTests -Pheadless'
+            javaHomeOption: 'JDKVersion'
+            jdkVersionOption: '1.11'
+            jdkArchitectureOption: 'x64'
+            publishJUnitResults: true
+            testResultsFiles: '**/TEST-*.xml'
+            tasks: 'jacocoRootReport'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,9 @@ stages:
             jdkArchitectureOption: 'x64'
             publishJUnitResults: true
             testResultsFiles: '**/TEST-*.xml'
-            tasks: 'check jacocoTestReport'
+            tasks: 'check jacocoRootReport'
 
-        - bash: bash <(curl -s https://codecov.io/bash) -f "*jacocoTestReport.xml" -f "*mergeReports.xml" || echo 'Codecov failed to upload'
+        - bash: bash <(curl -s https://codecov.io/bash) -f "build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml" || echo 'Codecov failed to upload'
           displayName: 'CodeCov'
           workingDirectory: ''
           env:
@@ -52,7 +52,7 @@ stages:
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
-            tasks: 'check jacocoTestReport'
+            tasks: 'check jacocoRootReport'
 
     - job: Windows
 
@@ -71,4 +71,4 @@ stages:
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
-            tasks: 'check jacocoTestReport'
+            tasks: 'check jacocoRootReport'


### PR DESCRIPTION
### Description of the Change

This PR adds a task to aggregate Jacoco reports so that the coverage reporting is accurate (Jacoco can't handle cross-module reports without aggregation).

### Motivation

Inaccurate coverage reporting isn't useful.

### Verification Process

The coverage on this PR should be around 88%, compared to the 83% currently on master.

### Applicable Issues

None.
