### PR TITLE
Add checkpoint callback Task

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/CheckpointCallbackTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/CheckpointCallbackTask.kt
@@ -1,0 +1,85 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.imports.makeImport
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.tfdata.ModelCheckpointSaveFrequency
+import edu.wpi.axon.tfdata.code.boolToPythonString
+import edu.wpi.axon.tfdata.code.numberToPythonString
+import edu.wpi.axon.util.singleAssign
+
+/**
+ * Makes a new `ModelCheckpoint` callback.
+ */
+class CheckpointCallbackTask(name: String) : BaseTask(name) {
+
+    /**
+     * The formatted file path.
+     * https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/ModelCheckpoint
+     */
+    var filePath: String by singleAssign()
+
+    /**
+     * The quantity to monitor.
+     */
+    var monitor = "val_loss"
+
+    /**
+     * The verbosity mode: `0` or `1`.
+     */
+    var verbose = 0
+
+    /**
+     * If `true`, the latest best model will not be overwritten.
+     */
+    var saveBestOnly = false
+
+    /**
+     * One of `auto`, `min`, `max`. Used to determine when to overwrite the current save file
+     * if [saveBestOnly] is `true`.
+     */
+    var mode = "auto"
+
+    /**
+     * If `true`, only the model's weights will be saved. Else, the full model will be saved.
+     */
+    var saveWeightsOnly = false
+
+    /**
+     * How frequently to make checkpoints.
+     */
+    var saveFrequency: ModelCheckpointSaveFrequency = ModelCheckpointSaveFrequency.Epoch
+
+    /**
+     * If `true`, the model will attempt to load the checkpoint file at the start of training.
+     */
+    var loadWeightsOnRestart = false
+
+    /**
+     * Where to save the callback to.
+     */
+    var output: Variable by singleAssign()
+
+    override val imports: Set<Import> = setOf(makeImport("import tensorflow as tf"))
+
+    override val inputs: Set<Variable> = setOf()
+
+    override val outputs: Set<Variable>
+        get() = setOf(output)
+
+    override val dependencies: Set<Code<*>> = setOf()
+
+    override fun code() = """
+        |${output.name} = tf.keras.callbacks.ModelCheckpoint(
+        |    "$filePath",
+        |    monitor="$monitor",
+        |    verbose=${numberToPythonString(verbose)},
+        |    save_best_only=${boolToPythonString(saveBestOnly)},
+        |    save_weights_only=${boolToPythonString(saveWeightsOnly)},
+        |    mode="$mode",
+        |    save_freq=$saveFrequency,
+        |    load_weights_on_restart=${boolToPythonString(loadWeightsOnRestart)}
+        |)
+    """.trimMargin()
+}

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/CheckpointCallbackTaskConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/CheckpointCallbackTaskConfigurationTest.kt
@@ -1,0 +1,11 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.TaskConfigurationTestFixture
+
+internal class CheckpointCallbackTaskConfigurationTest :
+    TaskConfigurationTestFixture<CheckpointCallbackTask>(
+        { CheckpointCallbackTask("").apply { filePath = "" } },
+        listOf(
+            CheckpointCallbackTask::output
+        )
+    )

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/CheckpointCallbackTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/CheckpointCallbackTaskTest.kt
@@ -1,0 +1,41 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.configuredCorrectly
+import edu.wpi.axon.testutil.KoinTestFixture
+import edu.wpi.axon.tfdata.ModelCheckpointSaveFrequency
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+
+internal class CheckpointCallbackTaskTest : KoinTestFixture() {
+
+    @Test
+    fun `test code gen`() {
+        startKoin { }
+
+        val task = CheckpointCallbackTask("").apply {
+            filePath = "weights.{epoch:02d}-{val_loss:.2f}.hdf5"
+            monitor = "val_loss"
+            verbose = 0
+            saveBestOnly = false
+            saveWeightsOnly = false
+            mode = "auto"
+            saveFrequency = ModelCheckpointSaveFrequency.Epoch
+            loadWeightsOnRestart = false
+            output = configuredCorrectly("output")
+        }
+
+        task.code() shouldBe """
+            |output = tf.keras.callbacks.ModelCheckpoint(
+            |    "weights.{epoch:02d}-{val_loss:.2f}.hdf5",
+            |    monitor="val_loss",
+            |    verbose=0,
+            |    save_best_only=False,
+            |    save_weights_only=False,
+            |    mode="auto",
+            |    save_freq="epoch",
+            |    load_weights_on_restart=False
+            |)
+        """.trimMargin()
+    }
+}

--- a/tf-data/src/main/kotlin/edu/wpi/axon/tfdata/ModelCheckpointSaveFrequency.kt
+++ b/tf-data/src/main/kotlin/edu/wpi/axon/tfdata/ModelCheckpointSaveFrequency.kt
@@ -1,0 +1,19 @@
+package edu.wpi.axon.tfdata
+
+sealed class ModelCheckpointSaveFrequency {
+
+    /**
+     * Checkpoint after each epoch.
+     */
+    object Epoch : ModelCheckpointSaveFrequency() {
+        override fun toString() = """"epoch""""
+    }
+
+    /**
+     * Checkpoint at the end of a batch at which [numSamplesPerCheckpoint] number of samples have
+     * been seen since the last checkpoint. This can produce less reliable metrics than [Epoch].
+     */
+    data class Samples(val numSamplesPerCheckpoint: Int) : ModelCheckpointSaveFrequency() {
+        override fun toString() = numSamplesPerCheckpoint.toString()
+    }
+}

--- a/tf-data/src/test/kotlin/edu/wpi/axon/tfdata/ModelCheckpointSaveFrequencyTest.kt
+++ b/tf-data/src/test/kotlin/edu/wpi/axon/tfdata/ModelCheckpointSaveFrequencyTest.kt
@@ -1,0 +1,17 @@
+package edu.wpi.axon.tfdata
+
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class ModelCheckpointSaveFrequencyTest {
+
+    @Test
+    fun `test epoch`() {
+        ModelCheckpointSaveFrequency.Epoch.toString() shouldBe """"epoch""""
+    }
+
+    @Test
+    fun `test integer`() {
+        ModelCheckpointSaveFrequency.Samples(10).toString() shouldBe "10"
+    }
+}

--- a/training/src/test/kotlin/edu/wpi/axon/training/TrainingIntegrationTest.kt
+++ b/training/src/test/kotlin/edu/wpi/axon/training/TrainingIntegrationTest.kt
@@ -68,6 +68,17 @@ internal class TrainingIntegrationTest : KoinTestFixture() {
             |newModel.get_layer("dropout_7").trainable = True
             |newModel.get_layer("dense_7").trainable = True
             |
+            |checkpointCallback = tf.keras.callbacks.ModelCheckpoint(
+            |    "sequential_3-weights.{epoch:02d}-{val_loss:.2f}.hdf5",
+            |    monitor="val_loss",
+            |    verbose=1,
+            |    save_best_only=False,
+            |    save_weights_only=True,
+            |    mode="auto",
+            |    save_freq="epoch",
+            |    load_weights_on_restart=False
+            |)
+            |
             |newModel.compile(
             |    optimizer=tf.keras.optimizers.Adam(0.001, 0.9, 0.999, 1.0E-7, False),
             |    loss=tf.keras.losses.sparse_categorical_crossentropy,
@@ -86,7 +97,7 @@ internal class TrainingIntegrationTest : KoinTestFixture() {
             |    batch_size=None,
             |    epochs=50,
             |    verbose=2,
-            |    callbacks=[],
+            |    callbacks=[checkpointCallback],
             |    validation_data=(scaledXTest, yTest),
             |    shuffle=True
             |)


### PR DESCRIPTION
### Description of the Change

This PR adds a Task that can make a checkpoint callback and uses it in Training.

### Motivation

Checkpoints are an important part of the training process.

### Verification Process

Added tests and ran the training integ test in a notebook.

### Applicable Issues

Closes #53.
