### PR TITLE
Support EarlyStopping

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTask.kt
@@ -1,0 +1,78 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.Code
+import edu.wpi.axon.dsl.imports.Import
+import edu.wpi.axon.dsl.imports.makeImport
+import edu.wpi.axon.dsl.variable.Variable
+import edu.wpi.axon.tfdata.code.boolToPythonString
+import edu.wpi.axon.tfdata.code.numberToPythonString
+import edu.wpi.axon.util.singleAssign
+
+class EarlyStoppingTask(name: String) : BaseTask(name) {
+
+    /**
+     * The quantity to be monitored.
+     */
+    var monitor: String = "val_loss"
+
+    /**
+     * The minimum change in the monitored quantity to qualify as an improvement.
+     */
+    var minDelta: Number = 0
+
+    /**
+     * The number of epochs with no improvement after which training will be stopped.
+     */
+    var patience: Int = 0
+
+    /**
+     * The verbosity.
+     */
+    var verbose: Int = 0
+
+    /**
+     * One of `auto`, `min`, `max`. In `min` mode, training will stop when the quantity monitored
+     * has stopped decreasing; in `max` mode it will stop when the quantity monitored has stopped
+     * increasing; in `auto` mode, the direction is automatically inferred from the name of the
+     * monitored quantity.
+     */
+    var mode: String = "auto"
+
+    /**
+     * A baseline value for the monitored quantity. Training will stop if the model doesn't show
+     * improvement over the baseline.
+     */
+    var baseline: Number? = null
+
+    /**
+     * Whether to restore model weights from the epoch with the best value of the monitored
+     * quantity.
+     */
+    var restoreBestWeights: Boolean = false
+
+    /**
+     * Where to save the callback to.
+     */
+    var output: Variable by singleAssign()
+
+    override val imports: Set<Import> = setOf(makeImport("import tensorflow as ft"))
+
+    override val inputs: Set<Variable> = setOf()
+
+    override val outputs: Set<Variable>
+        get() = setOf(output)
+
+    override val dependencies: Set<Code<*>> = setOf()
+
+    override fun code() = """
+        |${output.name} = tf.keras.callbacks.EarlyStopping(
+        |    monitor="$monitor",
+        |    min_delta=$minDelta,
+        |    patience=$patience,
+        |    verbose=$verbose,
+        |    mode="$mode",
+        |    baseline=${numberToPythonString(baseline)},
+        |    restore_best_weights=${boolToPythonString(restoreBestWeights)}
+        |)
+    """.trimMargin()
+}

--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTask.kt
@@ -55,7 +55,7 @@ class EarlyStoppingTask(name: String) : BaseTask(name) {
      */
     var output: Variable by singleAssign()
 
-    override val imports: Set<Import> = setOf(makeImport("import tensorflow as ft"))
+    override val imports: Set<Import> = setOf(makeImport("import tensorflow as tf"))
 
     override val inputs: Set<Variable> = setOf()
 

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTaskConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTaskConfigurationTest.kt
@@ -1,0 +1,8 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.TaskConfigurationTestFixture
+
+internal class EarlyStoppingTaskConfigurationTest : TaskConfigurationTestFixture<EarlyStoppingTask>(
+    EarlyStoppingTask::class,
+    listOf(EarlyStoppingTask::output)
+)

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/EarlyStoppingTaskTest.kt
@@ -1,0 +1,38 @@
+package edu.wpi.axon.dsl.task
+
+import edu.wpi.axon.dsl.configuredCorrectly
+import edu.wpi.axon.testutil.KoinTestFixture
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+
+internal class EarlyStoppingTaskTest : KoinTestFixture() {
+
+    @Test
+    fun `test code gen`() {
+        startKoin {}
+
+        val task = EarlyStoppingTask("").apply {
+            monitor = "val_loss"
+            minDelta = 0
+            patience = 0
+            verbose = 0
+            mode = "auto"
+            baseline = null
+            restoreBestWeights = false
+            output = configuredCorrectly("output")
+        }
+
+        task.code() shouldBe """
+            |output = tf.keras.callbacks.EarlyStopping(
+            |    monitor="val_loss",
+            |    min_delta=0,
+            |    patience=0,
+            |    verbose=0,
+            |    mode="auto",
+            |    baseline=None,
+            |    restore_best_weights=False
+            |)
+        """.trimMargin()
+    }
+}

--- a/training/src/main/kotlin/edu/wpi/axon/training/Training.kt
+++ b/training/src/main/kotlin/edu/wpi/axon/training/Training.kt
@@ -10,6 +10,7 @@ import edu.wpi.axon.dsl.running
 import edu.wpi.axon.dsl.task.ApplyLayerDeltaTask
 import edu.wpi.axon.dsl.task.CheckpointCallbackTask
 import edu.wpi.axon.dsl.task.CompileModelTask
+import edu.wpi.axon.dsl.task.EarlyStoppingTask
 import edu.wpi.axon.dsl.task.LoadExampleDatasetTask
 import edu.wpi.axon.dsl.task.LoadModelTask
 import edu.wpi.axon.dsl.task.ReshapeAndScaleTask
@@ -117,13 +118,20 @@ class Training(
                     output = checkpointCallback
                 }
 
+                val earlyStoppingCallback by variables.creating(Variable::class)
+                val earlyStoppingCallbackTask by tasks.running(EarlyStoppingTask::class) {
+                    patience = 10
+                    verbose = 1
+                    output = earlyStoppingCallback
+                }
+
                 val trainModelTask by tasks.running(TrainTask::class) {
                     modelInput = newModel
                     trainInputData = scaledXTrain
                     trainOutputData = yTrain
                     validationInputData = scaledXTest
                     validationOutputData = yTest
-                    callbacks = setOf(checkpointCallback)
+                    callbacks = setOf(checkpointCallback, earlyStoppingCallback)
                     epochs = userEpochs
                     dependencies += compileModelTask
                 }

--- a/training/src/test/kotlin/edu/wpi/axon/training/TrainingIntegrationTest.kt
+++ b/training/src/test/kotlin/edu/wpi/axon/training/TrainingIntegrationTest.kt
@@ -107,6 +107,16 @@ internal class TrainingIntegrationTest : KoinTestFixture() {
                     |    metrics=["accuracy"]
                     |)
                     |
+                    |earlyStoppingCallback = tf.keras.callbacks.EarlyStopping(
+                    |    monitor="val_loss",
+                    |    min_delta=0,
+                    |    patience=10,
+                    |    verbose=1,
+                    |    mode="auto",
+                    |    baseline=None,
+                    |    restore_best_weights=False
+                    |)
+                    |
                     |(xTrain, yTrain), (xTest, yTest) = tf.keras.datasets.mnist.load_data()
                     |
                     |scaledXTest = xTest.reshape(-1, 28, 28, 1) / 255
@@ -119,7 +129,7 @@ internal class TrainingIntegrationTest : KoinTestFixture() {
                     |    batch_size=None,
                     |    epochs=50,
                     |    verbose=2,
-                    |    callbacks=[checkpointCallback],
+                    |    callbacks=[checkpointCallback, earlyStoppingCallback],
                     |    validation_data=(scaledXTest, yTest),
                     |    shuffle=True
                     |)


### PR DESCRIPTION
### Description of the Change

This PR adds a Task that generates an EarlyStopping callback.

### Motivation

EarlyStopping is important to avoid unnecessary training time and cost.

### Verification Process

Added new tests for EarlyStoppingTask, added it to Training and adjusted the integ test, and testing the result by hand in a notebook.

### Applicable Issues

Closes #54.
