### PR TITLE
Move ui dep version numbers into gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@ dokkaPluginVersion=0.9.18
 testloggerPluginVersion=1.6.0
 pitestPluginVersion=1.4.5
 ktlint.version=0.29.0
+vaadinFlowPluginVersion=1.2
+grettyPluginVersion=2.3.1
+nodePluginVersion=1.3.1
 
 junit-jupiter.version=5.5.1
 junit-platform-launcher.version=1.5.1
@@ -36,3 +39,6 @@ kotlin-logging.version=1.6.26
 slf4j-log4j12.version=1.7.26
 apache-log4j-extras.version=1.2.17
 ascii-data.version=1.4.0
+vaadin.version=14.0.5
+jetty.version=9.4.20.v20190813
+karibu-testing-v10.version=1.1.11

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,9 @@ val detektPluginVersion: String by settings
 val dokkaPluginVersion: String by settings
 val testloggerPluginVersion: String by settings
 val pitestPluginVersion: String by settings
+val vaadinFlowPluginVersion: String by settings
+val grettyPluginVersion: String by settings
+val nodePluginVersion: String by settings
 
 pluginManagement {
     plugins {
@@ -17,6 +20,9 @@ pluginManagement {
         id("org.jetbrains.dokka") version dokkaPluginVersion
         id("com.adarshr.test-logger") version testloggerPluginVersion
         id("info.solidsoft.pitest") version pitestPluginVersion
+        id("com.devsoap.vaadin-flow") version vaadinFlowPluginVersion
+        id("org.gretty") version grettyPluginVersion
+        id("com.moowork.node") version nodePluginVersion
     }
 }
 
@@ -49,14 +55,14 @@ fun configureGradleBuild(project: ProjectDescriptor) {
     val kotlinBuild = File(project.projectDir, "$projectBuildFileBaseName.gradle.kts")
     assert(!(gradleBuild.exists() && kotlinBuild.exists())) {
         "Project ${project.name} can not have both a ${gradleBuild.name} and a ${kotlinBuild.name} file. " +
-                "Rename one so that the other can serve as the base for the project's build"
+            "Rename one so that the other can serve as the base for the project's build"
     }
     project.buildFileName = when {
         gradleBuild.exists() -> gradleBuild.name
         kotlinBuild.exists() -> kotlinBuild.name
         else -> throw AssertionError(
             "Project `${project.name}` must have a either a file " +
-                    "containing ${gradleBuild.name} or ${kotlinBuild.name}"
+                "containing ${gradleBuild.name} or ${kotlinBuild.name}"
         )
     }
 

--- a/ui-electron/ui-electron.gradle.kts
+++ b/ui-electron/ui-electron.gradle.kts
@@ -1,7 +1,7 @@
 import com.moowork.gradle.node.npm.NpmTask
 
 plugins {
-    id("com.moowork.node") version "1.3.1"
+    id("com.moowork.node")
 }
 
 node {
@@ -16,6 +16,7 @@ tasks {
 
         delete(vaadinDir)
     }
+
     val syncVaadinResources by registering(Sync::class) {
         group = "electron"
         dependsOn(":ui-vaadin:buildProduct")
@@ -23,13 +24,15 @@ tasks {
         from(projectDir.resolve("../ui-vaadin/build/output/ui-vaadin"))
         into(vaadinDir)
     }
-    val runbuildProduct by registering(NpmTask::class) {
+
+    val run_buildProduct by registering(NpmTask::class) {
         group = "electron"
         dependsOn("npmInstall", syncVaadinResources)
 
         setArgs(listOf("start"))
     }
-    val bundle by registering(NpmTask::class) {
+
+    val bundle_buildProduct by registering(NpmTask::class) {
         group = "electron"
         dependsOn("npmInstall", syncVaadinResources)
 
@@ -39,6 +42,7 @@ tasks {
     clean {
         dependsOn(cleanVaadinResources)
     }
+
     assemble {
         dependsOn(syncVaadinResources)
     }

--- a/ui-vaadin/ui-vaadin.gradle.kts
+++ b/ui-vaadin/ui-vaadin.gradle.kts
@@ -1,27 +1,30 @@
 plugins {
-    id("org.gretty") version "2.3.1"
-    id("com.devsoap.vaadin-flow") version "1.2"
+    id("org.gretty")
+    id("com.devsoap.vaadin-flow")
 }
 
 dependencies {
     fun jetty(
         group: String = "org.eclipse.jetty",
         name: String,
-        version: String = "9.4.20.v20190813"
+        version: String = property("jetty.version") as String
     ) = create(group = group, name = name, version = version)
 
     implementation(jetty(name = "jetty-server"))
     implementation(jetty(name = "jetty-webapp"))
     implementation(jetty(group = "org.eclipse.jetty.websocket", name = "websocket-server"))
 
-    testImplementation("com.github.mvysny.kaributesting:karibu-testing-v10:1.1.11")
+    testImplementation(
+        group = "com.github.mvysny.kaributesting",
+        name = "karibu-testing-v10",
+        version = property("karibu-testing-v10.version") as String
+    )
 }
 
 gretty {
     // https://akhikhl.github.io/gretty-doc/Gretty-configuration.html
     host = "localhost"
     httpPort = 8080
-
     contextPath = "axon"
 }
 
@@ -30,9 +33,8 @@ node {
 }
 
 vaadin {
-    version = "14.0.5"
+    version = property("vaadin.version") as String
     isProductionMode = false
     isSubmitStatistics = false
-
     autoconfigure()
 }


### PR DESCRIPTION
### Description of the Change

This PR moves the version numbers introduced in #64 into `gradle.properties`.

### Motivation

Centralized version numbers allow less room for mistakes.

### Verification Process

The application still runs.

### Applicable Issues

Closes #66.
