### PR TITLE
Removed unneeded dependancies from UI project

### DIFF
--- a/ui-vaadin/ui-vaadin.gradle.kts
+++ b/ui-vaadin/ui-vaadin.gradle.kts
@@ -3,24 +3,6 @@ plugins {
     id("com.devsoap.vaadin-flow")
 }
 
-dependencies {
-    fun jetty(
-        group: String = "org.eclipse.jetty",
-        name: String,
-        version: String = property("jetty.version") as String
-    ) = create(group = group, name = name, version = version)
-
-    implementation(jetty(name = "jetty-server"))
-    implementation(jetty(name = "jetty-webapp"))
-    implementation(jetty(group = "org.eclipse.jetty.websocket", name = "websocket-server"))
-
-    testImplementation(
-        group = "com.github.mvysny.kaributesting",
-        name = "karibu-testing-v10",
-        version = property("karibu-testing-v10.version") as String
-    )
-}
-
 gretty {
     // https://akhikhl.github.io/gretty-doc/Gretty-configuration.html
     host = "localhost"
@@ -36,5 +18,16 @@ vaadin {
     version = property("vaadin.version") as String
     isProductionMode = false
     isSubmitStatistics = false
-    autoconfigure()
+}
+
+dependencies {
+    implementation(platform(vaadin.bom()))
+    implementation(vaadin.core())
+    implementation(vaadin.lumoTheme())
+
+    testImplementation(
+        group = "com.github.mvysny.kaributesting",
+        name = "karibu-testing-v10",
+        version = property("karibu-testing-v10.version") as String
+    )
 }


### PR DESCRIPTION
We do not need the jetty dependancies because we are using the Gretty plugin.  Also, Vaadin autoconfigure added a bunch of features we cannot use because we are not paying for them.