### PR TITLE
Rename sequential-only classes

### DIFF
--- a/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplySequentialLayerDeltaTask.kt
+++ b/dsl/src/main/kotlin/edu/wpi/axon/dsl/task/ApplySequentialLayerDeltaTask.kt
@@ -16,9 +16,9 @@ private sealed class LayerOperation(open val layer: SealedLayer.MetaLayer) {
 }
 
 /**
- * Adds and removes layers on a new model using a starting model.
+ * Adds and removes layers on a new model using a starting Sequential model.
  */
-class ApplyLayerDeltaTask(name: String) : BaseTask(name) {
+class ApplySequentialLayerDeltaTask(name: String) : BaseTask(name) {
 
     /**
      * The model to take the starting layers from.

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaConfigurationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplyLayerDeltaConfigurationTest.kt
@@ -2,9 +2,9 @@ package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.TaskConfigurationTestFixture
 
-internal class ApplyLayerDeltaConfigurationTest : TaskConfigurationTestFixture<ApplyLayerDeltaTask>(
-    ApplyLayerDeltaTask::class,
+internal class ApplyLayerDeltaConfigurationTest : TaskConfigurationTestFixture<ApplySequentialLayerDeltaTask>(
+    ApplySequentialLayerDeltaTask::class,
     listOf(
-        ApplyLayerDeltaTask::modelInput, ApplyLayerDeltaTask::newModelOutput
+        ApplySequentialLayerDeltaTask::modelInput, ApplySequentialLayerDeltaTask::newModelOutput
     )
 )

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplySequentialLayerDeltaTaskIntegrationTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplySequentialLayerDeltaTaskIntegrationTest.kt
@@ -3,28 +3,26 @@
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.configuredCorrectly
-import edu.wpi.axon.dsl.defaultUniqueVariableNameGenerator
+import edu.wpi.axon.dsl.defaultModule
 import edu.wpi.axon.testutil.KoinTestFixture
-import edu.wpi.axon.tfdata.code.layer.LayerToCode
 import edu.wpi.axon.tfdata.layer.Activation
 import edu.wpi.axon.tfdata.layer.SealedLayer
 import edu.wpi.axon.tfdata.layer.trainable
 import io.kotlintest.shouldBe
-import io.mockk.every
-import io.mockk.mockk
+import io.kotlintest.shouldThrow
 import org.junit.jupiter.api.Test
 import org.koin.core.context.startKoin
-import org.koin.dsl.module
 
-internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
+internal class ApplySequentialLayerDeltaTaskIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `keep all 1 layers`() {
-        startKoin {}
+        startKoin {
+            modules(defaultModule())
+        }
 
         val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
-
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1)
             newLayers = setOf(layer1)
@@ -39,12 +37,13 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
     @Test
     fun `keep all 2 layers`() {
-        startKoin {}
+        startKoin {
+            modules(defaultModule())
+        }
 
         val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
         val layer2 = SealedLayer.UnknownLayer("unknown_1").trainable()
-
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1, layer2)
             newLayers = setOf(layer1, layer2)
@@ -63,9 +62,11 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
     @Test
     fun `remove one layer`() {
-        startKoin {}
+        startKoin {
+            modules(defaultModule())
+        }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable())
             newLayers = setOf()
@@ -80,9 +81,11 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
     @Test
     fun `remove two layers`() {
-        startKoin {}
+        startKoin {
+            modules(defaultModule())
+        }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(
                 SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable(),
@@ -100,60 +103,43 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
     @Test
     fun `add one layer`() {
-        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
-
         startKoin {
-            modules(module {
-                defaultUniqueVariableNameGenerator()
-                single<LayerToCode> {
-                    mockk {
-                        every { makeNewLayer(layer1) } returns "layer1"
-                    }
-                }
-            })
+            modules(defaultModule())
         }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf()
-            newLayers = setOf(layer1)
+            newLayers = setOf(SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable())
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
-            |new_model = tf.keras.Sequential([layer1])
+            |new_model = tf.keras.Sequential([tf.keras.layers.Dense(name="dense_1", units=10, activation=tf.keras.activations.relu)])
             |new_model.get_layer("dense_1").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `add two layers`() {
-        val layer1 = SealedLayer.Dense("dense_1", 128, Activation.ReLu).trainable()
-        val layer2 = SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
-
         startKoin {
-            modules(module {
-                defaultUniqueVariableNameGenerator()
-                single<LayerToCode> {
-                    mockk {
-                        every { makeNewLayer(layer1) } returns "layer1"
-                        every { makeNewLayer(layer2) } returns "layer2"
-                    }
-                }
-            })
+            modules(defaultModule())
         }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf()
-            newLayers = setOf(layer1, layer2)
+            newLayers = setOf(
+                SealedLayer.Dense("dense_1", 128, Activation.ReLu).trainable(),
+                SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
+            )
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([
-            |    layer1,
-            |    layer2
+            |    tf.keras.layers.Dense(name="dense_1", units=128, activation=tf.keras.activations.relu),
+            |    tf.keras.layers.Dense(name="dense_2", units=10, activation=tf.keras.activations.softmax)
             |])
             |new_model.get_layer("dense_1").trainable = True
             |new_model.get_layer("dense_2").trainable = True
@@ -161,46 +147,81 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
     }
 
     @Test
-    fun `remove the first layer and replace the second and swap them`() {
-        val layer1 = SealedLayer.UnknownLayer("unknown_3").trainable()
-        val layer2Old = SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
-        val layer2New = SealedLayer.Dense("dense_2", 3, Activation.SoftMax).trainable()
-
+    fun `add an unknown layer`() {
         startKoin {
-            modules(module {
-                defaultUniqueVariableNameGenerator()
-                single<LayerToCode> {
-                    mockk {
-                        every { makeNewLayer(layer2New) } returns "layer2New"
-                    }
-                }
-            })
+            modules(defaultModule())
         }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
-            currentLayers = setOf(layer1, layer2Old)
-            newLayers = setOf(layer2New, layer1)
+            currentLayers = setOf()
+            newLayers = setOf(SealedLayer.UnknownLayer("layer_1").trainable())
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        shouldThrow<IllegalArgumentException> { task.code() }
+    }
+
+    @Test
+    fun `add layer with an unknown activation function`() {
+        startKoin {
+            modules(defaultModule())
+        }
+
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            currentLayers = setOf()
+            newLayers = setOf(
+                SealedLayer.Dense(
+                    "dense_1",
+                    128,
+                    Activation.UnknownActivation("activation_1")
+                ).trainable()
+            )
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        shouldThrow<IllegalArgumentException> { task.code() }
+    }
+
+    @Test
+    fun `remove the first layer and replace the second`() {
+        startKoin {
+            modules(defaultModule())
+        }
+
+        val layer1 = SealedLayer.UnknownLayer("unknown_3").trainable()
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            currentLayers = setOf(
+                layer1,
+                SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
+            )
+            newLayers = setOf(
+                layer1,
+                SealedLayer.Dense("dense_2", 3, Activation.SoftMax).trainable()
+            )
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([
-            |    layer2New,
-            |    base_model.get_layer("unknown_3")
+            |    base_model.get_layer("unknown_3"),
+            |    tf.keras.layers.Dense(name="dense_2", units=3, activation=tf.keras.activations.softmax)
             |])
-            |new_model.get_layer("dense_2").trainable = True
             |new_model.get_layer("unknown_3").trainable = True
+            |new_model.get_layer("dense_2").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `copy an unknown layer`() {
-        startKoin {}
+        startKoin {
+            modules(defaultModule())
+        }
 
         val layer1 = SealedLayer.UnknownLayer("unknown_1").trainable()
-
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1)
             newLayers = setOf(layer1)
@@ -215,11 +236,17 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
 
     @Test
     fun `copy a layer with an unknown activation function`() {
-        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.UnknownActivation("activation_1"))
-            .trainable()
-        startKoin {}
+        startKoin {
+            modules(defaultModule())
+        }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val layer1 = SealedLayer.Dense(
+            "dense_1",
+            10,
+            Activation.UnknownActivation("activation_1")
+        ).trainable()
+
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1)
             newLayers = setOf(layer1)
@@ -229,6 +256,26 @@ internal class ApplyLayerDeltaTaskTest : KoinTestFixture() {
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([base_model.get_layer("dense_1")])
             |new_model.get_layer("dense_1").trainable = True
+        """.trimMargin()
+    }
+
+    @Test
+    fun `copy a layer that is only different in the trainable flag`() {
+        startKoin {
+            modules(defaultModule())
+        }
+
+        val baseLayer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu)
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
+            modelInput = configuredCorrectly("base_model")
+            currentLayers = setOf(baseLayer1.trainable())
+            newLayers = setOf(baseLayer1.trainable(false))
+            newModelOutput = configuredCorrectly("new_model")
+        }
+
+        task.code() shouldBe """
+            |new_model = tf.keras.Sequential([base_model.get_layer("dense_1")])
+            |new_model.get_layer("dense_1").trainable = False
         """.trimMargin()
     }
 }

--- a/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplySequentialLayerDeltaTaskTest.kt
+++ b/dsl/src/test/kotlin/edu/wpi/axon/dsl/task/ApplySequentialLayerDeltaTaskTest.kt
@@ -3,26 +3,28 @@
 package edu.wpi.axon.dsl.task
 
 import edu.wpi.axon.dsl.configuredCorrectly
-import edu.wpi.axon.dsl.defaultModule
+import edu.wpi.axon.dsl.defaultUniqueVariableNameGenerator
 import edu.wpi.axon.testutil.KoinTestFixture
+import edu.wpi.axon.tfdata.code.layer.LayerToCode
 import edu.wpi.axon.tfdata.layer.Activation
 import edu.wpi.axon.tfdata.layer.SealedLayer
 import edu.wpi.axon.tfdata.layer.trainable
 import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.koin.core.context.startKoin
+import org.koin.dsl.module
 
-internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
+internal class ApplySequentialLayerDeltaTaskTest : KoinTestFixture() {
 
     @Test
     fun `keep all 1 layers`() {
-        startKoin {
-            modules(defaultModule())
-        }
+        startKoin {}
 
         val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
-        val task = ApplyLayerDeltaTask("task1").apply {
+
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1)
             newLayers = setOf(layer1)
@@ -37,13 +39,12 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `keep all 2 layers`() {
-        startKoin {
-            modules(defaultModule())
-        }
+        startKoin {}
 
         val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
         val layer2 = SealedLayer.UnknownLayer("unknown_1").trainable()
-        val task = ApplyLayerDeltaTask("task1").apply {
+
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1, layer2)
             newLayers = setOf(layer1, layer2)
@@ -62,11 +63,9 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `remove one layer`() {
-        startKoin {
-            modules(defaultModule())
-        }
+        startKoin {}
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable())
             newLayers = setOf()
@@ -81,11 +80,9 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `remove two layers`() {
-        startKoin {
-            modules(defaultModule())
-        }
+        startKoin {}
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(
                 SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable(),
@@ -103,43 +100,60 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `add one layer`() {
+        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable()
+
         startKoin {
-            modules(defaultModule())
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+                single<LayerToCode> {
+                    mockk {
+                        every { makeNewLayer(layer1) } returns "layer1"
+                    }
+                }
+            })
         }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf()
-            newLayers = setOf(SealedLayer.Dense("dense_1", 10, Activation.ReLu).trainable())
+            newLayers = setOf(layer1)
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
-            |new_model = tf.keras.Sequential([tf.keras.layers.Dense(name="dense_1", units=10, activation=tf.keras.activations.relu)])
+            |new_model = tf.keras.Sequential([layer1])
             |new_model.get_layer("dense_1").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `add two layers`() {
+        val layer1 = SealedLayer.Dense("dense_1", 128, Activation.ReLu).trainable()
+        val layer2 = SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
+
         startKoin {
-            modules(defaultModule())
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+                single<LayerToCode> {
+                    mockk {
+                        every { makeNewLayer(layer1) } returns "layer1"
+                        every { makeNewLayer(layer2) } returns "layer2"
+                    }
+                }
+            })
         }
 
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf()
-            newLayers = setOf(
-                SealedLayer.Dense("dense_1", 128, Activation.ReLu).trainable(),
-                SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
-            )
+            newLayers = setOf(layer1, layer2)
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([
-            |    tf.keras.layers.Dense(name="dense_1", units=128, activation=tf.keras.activations.relu),
-            |    tf.keras.layers.Dense(name="dense_2", units=10, activation=tf.keras.activations.softmax)
+            |    layer1,
+            |    layer2
             |])
             |new_model.get_layer("dense_1").trainable = True
             |new_model.get_layer("dense_2").trainable = True
@@ -147,81 +161,46 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
     }
 
     @Test
-    fun `add an unknown layer`() {
-        startKoin {
-            modules(defaultModule())
-        }
-
-        val task = ApplyLayerDeltaTask("task1").apply {
-            modelInput = configuredCorrectly("base_model")
-            currentLayers = setOf()
-            newLayers = setOf(SealedLayer.UnknownLayer("layer_1").trainable())
-            newModelOutput = configuredCorrectly("new_model")
-        }
-
-        shouldThrow<IllegalArgumentException> { task.code() }
-    }
-
-    @Test
-    fun `add layer with an unknown activation function`() {
-        startKoin {
-            modules(defaultModule())
-        }
-
-        val task = ApplyLayerDeltaTask("task1").apply {
-            modelInput = configuredCorrectly("base_model")
-            currentLayers = setOf()
-            newLayers = setOf(
-                SealedLayer.Dense(
-                    "dense_1",
-                    128,
-                    Activation.UnknownActivation("activation_1")
-                ).trainable()
-            )
-            newModelOutput = configuredCorrectly("new_model")
-        }
-
-        shouldThrow<IllegalArgumentException> { task.code() }
-    }
-
-    @Test
-    fun `remove the first layer and replace the second`() {
-        startKoin {
-            modules(defaultModule())
-        }
-
+    fun `remove the first layer and replace the second and swap them`() {
         val layer1 = SealedLayer.UnknownLayer("unknown_3").trainable()
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val layer2Old = SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
+        val layer2New = SealedLayer.Dense("dense_2", 3, Activation.SoftMax).trainable()
+
+        startKoin {
+            modules(module {
+                defaultUniqueVariableNameGenerator()
+                single<LayerToCode> {
+                    mockk {
+                        every { makeNewLayer(layer2New) } returns "layer2New"
+                    }
+                }
+            })
+        }
+
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
-            currentLayers = setOf(
-                layer1,
-                SealedLayer.Dense("dense_2", 10, Activation.SoftMax).trainable()
-            )
-            newLayers = setOf(
-                layer1,
-                SealedLayer.Dense("dense_2", 3, Activation.SoftMax).trainable()
-            )
+            currentLayers = setOf(layer1, layer2Old)
+            newLayers = setOf(layer2New, layer1)
             newModelOutput = configuredCorrectly("new_model")
         }
 
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([
-            |    base_model.get_layer("unknown_3"),
-            |    tf.keras.layers.Dense(name="dense_2", units=3, activation=tf.keras.activations.softmax)
+            |    layer2New,
+            |    base_model.get_layer("unknown_3")
             |])
-            |new_model.get_layer("unknown_3").trainable = True
             |new_model.get_layer("dense_2").trainable = True
+            |new_model.get_layer("unknown_3").trainable = True
         """.trimMargin()
     }
 
     @Test
     fun `copy an unknown layer`() {
-        startKoin {
-            modules(defaultModule())
-        }
+        startKoin {}
 
         val layer1 = SealedLayer.UnknownLayer("unknown_1").trainable()
-        val task = ApplyLayerDeltaTask("task1").apply {
+
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1)
             newLayers = setOf(layer1)
@@ -236,17 +215,11 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `copy a layer with an unknown activation function`() {
-        startKoin {
-            modules(defaultModule())
-        }
+        val layer1 = SealedLayer.Dense("dense_1", 10, Activation.UnknownActivation("activation_1"))
+            .trainable()
+        startKoin {}
 
-        val layer1 = SealedLayer.Dense(
-            "dense_1",
-            10,
-            Activation.UnknownActivation("activation_1")
-        ).trainable()
-
-        val task = ApplyLayerDeltaTask("task1").apply {
+        val task = ApplySequentialLayerDeltaTask("task1").apply {
             modelInput = configuredCorrectly("base_model")
             currentLayers = setOf(layer1)
             newLayers = setOf(layer1)
@@ -256,26 +229,6 @@ internal class ApplyLayerDeltaTaskIntegrationTest : KoinTestFixture() {
         task.code() shouldBe """
             |new_model = tf.keras.Sequential([base_model.get_layer("dense_1")])
             |new_model.get_layer("dense_1").trainable = True
-        """.trimMargin()
-    }
-
-    @Test
-    fun `copy a layer that is only different in the trainable flag`() {
-        startKoin {
-            modules(defaultModule())
-        }
-
-        val baseLayer1 = SealedLayer.Dense("dense_1", 10, Activation.ReLu)
-        val task = ApplyLayerDeltaTask("task1").apply {
-            modelInput = configuredCorrectly("base_model")
-            currentLayers = setOf(baseLayer1.trainable())
-            newLayers = setOf(baseLayer1.trainable(false))
-            newModelOutput = configuredCorrectly("new_model")
-        }
-
-        task.code() shouldBe """
-            |new_model = tf.keras.Sequential([base_model.get_layer("dense_1")])
-            |new_model.get_layer("dense_1").trainable = False
         """.trimMargin()
     }
 }

--- a/training/src/main/kotlin/edu/wpi/axon/training/TrainSequential.kt
+++ b/training/src/main/kotlin/edu/wpi/axon/training/TrainSequential.kt
@@ -7,7 +7,7 @@ import edu.wpi.axon.dsl.ScriptGenerator
 import edu.wpi.axon.dsl.container.DefaultPolymorphicNamedDomainObjectContainer
 import edu.wpi.axon.dsl.creating
 import edu.wpi.axon.dsl.running
-import edu.wpi.axon.dsl.task.ApplyLayerDeltaTask
+import edu.wpi.axon.dsl.task.ApplySequentialLayerDeltaTask
 import edu.wpi.axon.dsl.task.CheckpointCallbackTask
 import edu.wpi.axon.dsl.task.CompileModelTask
 import edu.wpi.axon.dsl.task.EarlyStoppingTask
@@ -25,7 +25,7 @@ import edu.wpi.axon.tflayerloader.LoadLayersFromHDF5
 import java.io.File
 
 /**
- * Trains a model.
+ * Trains a Sequential model.
  *
  * @param userModelPath The path to the model file.
  * @param userDataset The dataset to train on.
@@ -36,7 +36,7 @@ import java.io.File
  * @param userNewLayers The new layers (in the case of transfer learning).
  * @param generateDebugComments Whether to put debug comments in the output.
  */
-class Training(
+class TrainSequential(
     private val userModelPath: String,
     private val userDataset: Dataset,
     private val userOptimizer: Optimizer,
@@ -95,7 +95,7 @@ class Training(
                 }
 
                 val newModel by variables.creating(Variable::class)
-                val applyLayerDeltaTask by tasks.running(ApplyLayerDeltaTask::class) {
+                val applyLayerDeltaTask by tasks.running(ApplySequentialLayerDeltaTask::class) {
                     modelInput = model
                     currentLayers = currentModel.layers
                     newLayers = userNewLayers

--- a/training/src/test/kotlin/edu/wpi/axon/training/TrainSequentialIntegrationTest.kt
+++ b/training/src/test/kotlin/edu/wpi/axon/training/TrainSequentialIntegrationTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test
 import org.koin.core.context.startKoin
 import java.io.File
 
-internal class TrainingIntegrationTest : KoinTestFixture() {
+internal class TrainSequentialIntegrationTest : KoinTestFixture() {
 
     @Test
     fun `test with bad model`() {
@@ -25,10 +25,10 @@ internal class TrainingIntegrationTest : KoinTestFixture() {
             modules(defaultModule())
         }
 
-        val localModelPath = TrainingIntegrationTest::class.java
+        val localModelPath = TrainSequentialIntegrationTest::class.java
             .getResource("badModel1.h5").toURI().path
 
-        Training(
+        TrainSequential(
             userModelPath = localModelPath,
             userDataset = Dataset.Mnist,
             userOptimizer = Optimizer.Adam(0.001, 0.9, 0.999, 1e-7, false),
@@ -46,13 +46,13 @@ internal class TrainingIntegrationTest : KoinTestFixture() {
         }
 
         val modelName = "custom_fashion_mnist.h5"
-        val localModelPath = TrainingIntegrationTest::class.java
+        val localModelPath = TrainSequentialIntegrationTest::class.java
             .getResource(modelName).toURI().path
         val layers = LoadLayersFromHDF5().load(File(localModelPath))
 
         layers.attempt().unsafeRunSync().shouldBeRight { model ->
             model.shouldBeInstanceOf<Model.Sequential> {
-                Training(
+                TrainSequential(
                     userModelPath = localModelPath,
                     userDataset = Dataset.Mnist,
                     userOptimizer = Optimizer.Adam(0.001, 0.9, 0.999, 1e-7, false),


### PR DESCRIPTION
### Description of the Change

This PR renames everything that assumes a Sequential model so it is more obvious.

### Motivation

The Sequential-only distinction will be important once we support more models.

### Verification Process

N/A

### Applicable Issues

None.
