### PR TITLE
Create a model loading interface

### DIFF
--- a/example-models/src/main/kotlin/edu/wpi/axon/examplemodel/ExampleModelManager.kt
+++ b/example-models/src/main/kotlin/edu/wpi/axon/examplemodel/ExampleModelManager.kt
@@ -8,8 +8,7 @@ import arrow.fx.IO
 import arrow.fx.extensions.fx
 import edu.wpi.axon.tfdata.Model
 import edu.wpi.axon.tfdata.layer.Layer
-import edu.wpi.axon.tflayerloader.DefaultLayersToGraph
-import edu.wpi.axon.tflayerloader.LoadLayersFromHDF5
+import edu.wpi.axon.tflayerloader.ModelLoaderFactory
 import java.io.File
 import org.octogonapus.ktguava.collections.mapNodes
 
@@ -54,12 +53,13 @@ interface ExampleModelManager {
  * @param exampleModelManager The manager to download with.
  * @return The configured model.
  */
+@Suppress("UnstableApiUsage")
 fun downloadAndConfigureExampleModel(
     exampleModel: ExampleModel,
     exampleModelManager: ExampleModelManager
 ): IO<Tuple2<Model, File>> = IO.fx {
     val file = exampleModelManager.download(exampleModel).bind()
-    val model = LoadLayersFromHDF5(DefaultLayersToGraph()).load(File(file.absolutePath)).bind()
+    val model = ModelLoaderFactory().createModeLoader(file.name).load(File(file.absolutePath)).bind()
 
     val freezeLayerTransform: (Layer.MetaLayer) -> Layer.MetaLayer = { layer ->
         exampleModel.freezeLayers[layer.name]?.let {

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/HDF5ModelLoader.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/HDF5ModelLoader.kt
@@ -27,7 +27,7 @@ import java.io.File
 /**
  * Loads TensorFlow layers from an HDF5 file.
  */
-internal class LoadLayersFromHDF5(
+internal class HDF5ModelLoader(
     private val layersToGraph: LayersToGraph
 ) : ModelLoader {
 

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/LoadLayersFromHDF5.kt
@@ -27,9 +27,9 @@ import java.io.File
 /**
  * Loads TensorFlow layers from an HDF5 file.
  */
-class LoadLayersFromHDF5(
+internal class LoadLayersFromHDF5(
     private val layersToGraph: LayersToGraph
-) {
+) : ModelLoader {
 
     /**
      * Load layers from the [file].
@@ -37,7 +37,7 @@ class LoadLayersFromHDF5(
      * @param file The file to load from.
      * @return The layers in the file.
      */
-    fun load(file: File): IO<Model> = IO {
+    override fun load(file: File): IO<Model> = IO {
         HdfFile(file).use {
             val config = it.getAttribute("model_config").data as String
             val data = Parser.default().parse(config.byteInputStream()) as JsonObject

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/ModelLoader.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/ModelLoader.kt
@@ -1,0 +1,16 @@
+package edu.wpi.axon.tflayerloader
+
+import arrow.fx.IO
+import edu.wpi.axon.tfdata.Model
+import java.io.File
+
+interface ModelLoader {
+
+    /**
+     * Load a [Model] from the [file].
+     *
+     * @param file The file to load from.
+     * @return A new [Model] containing as much of the information from the [file] as possible.
+     */
+    fun load(file: File): IO<Model>
+}

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactory.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactory.kt
@@ -1,0 +1,16 @@
+package edu.wpi.axon.tflayerloader
+
+class ModelLoaderFactory {
+
+    /**
+     * Creates a new [ModelLoader] based on the extension of the [modelFilename].
+     *
+     * @param modelFilename The filename of the model file that is going to be loaded.
+     * @return A new [ModelLoader].
+     */
+    fun createModeLoader(modelFilename: String): ModelLoader = when {
+        modelFilename.endsWith(".h5") || modelFilename.endsWith(".hdf5") ->
+            LoadLayersFromHDF5(DefaultLayersToGraph())
+        else -> error("Model file type not supported for model with filename: $modelFilename")
+    }
+}

--- a/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactory.kt
+++ b/tf-layer-loader/src/main/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactory.kt
@@ -10,7 +10,7 @@ class ModelLoaderFactory {
      */
     fun createModeLoader(modelFilename: String): ModelLoader = when {
         modelFilename.endsWith(".h5") || modelFilename.endsWith(".hdf5") ->
-            LoadLayersFromHDF5(DefaultLayersToGraph())
+            HDF5ModelLoader(DefaultLayersToGraph())
         else -> error("Model file type not supported for model with filename: $modelFilename")
     }
 }

--- a/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/HDF5ModelLoaderIntegrationTest.kt
+++ b/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/HDF5ModelLoaderIntegrationTest.kt
@@ -17,7 +17,7 @@ import io.kotlintest.matchers.collections.shouldHaveSize
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 
-internal class LoadLayersFromHDF5IntegrationTest {
+internal class HDF5ModelLoaderIntegrationTest {
 
     @Test
     fun `load from test file 1`() {

--- a/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactoryTest.kt
+++ b/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactoryTest.kt
@@ -10,12 +10,12 @@ internal class ModelLoaderFactoryTest {
 
     @Test
     fun `test h5 file`() {
-        assertTrue(factory.createModeLoader("a.h5") is LoadLayersFromHDF5)
+        assertTrue(factory.createModeLoader("a.h5") is HDF5ModelLoader)
     }
 
     @Test
     fun `test hdf5 file`() {
-        assertTrue(factory.createModeLoader("a.hdf5") is LoadLayersFromHDF5)
+        assertTrue(factory.createModeLoader("a.hdf5") is HDF5ModelLoader)
     }
 
     @Test

--- a/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactoryTest.kt
+++ b/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/ModelLoaderFactoryTest.kt
@@ -1,0 +1,27 @@
+package edu.wpi.axon.tflayerloader
+
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class ModelLoaderFactoryTest {
+
+    private val factory = ModelLoaderFactory()
+
+    @Test
+    fun `test h5 file`() {
+        assertTrue(factory.createModeLoader("a.h5") is LoadLayersFromHDF5)
+    }
+
+    @Test
+    fun `test hdf5 file`() {
+        assertTrue(factory.createModeLoader("a.hdf5") is LoadLayersFromHDF5)
+    }
+
+    @Test
+    fun `test unknown file`() {
+        assertThrows<IllegalStateException> {
+            factory.createModeLoader("a.abcd")
+        }
+    }
+}

--- a/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/ModelTestUtil.kt
+++ b/tf-layer-loader/src/test/kotlin/edu/wpi/axon/tflayerloader/ModelTestUtil.kt
@@ -13,7 +13,7 @@ import java.io.File
  * @param block Will be run with the loaded model.
  */
 internal inline fun <reified T : Model> loadModel(filename: String, noinline block: (T) -> Unit) {
-    LoadLayersFromHDF5(DefaultLayersToGraph()).load(
+    HDF5ModelLoader(DefaultLayersToGraph()).load(
         File(block::class.java.getResource(filename).toURI())
     ).unsafeRunSync().apply { shouldBeInstanceOf(block) }
 }
@@ -25,7 +25,7 @@ internal inline fun <reified T : Model> loadModel(filename: String, noinline blo
  * @param stub Used to get the class to get a resource from. Do not use this parameter.
  */
 fun loadModelFails(filename: String, stub: () -> Unit = {}) {
-    LoadLayersFromHDF5(DefaultLayersToGraph()).load(
+    HDF5ModelLoader(DefaultLayersToGraph()).load(
         File(stub::class.java.getResource(filename).toURI())
     ).attempt().unsafeRunSync().shouldBeLeft()
 }

--- a/training-test-util/src/main/kotlin/edu/wpi/axon/training/testutil/TrainTestUtil.kt
+++ b/training-test-util/src/main/kotlin/edu/wpi/axon/training/testutil/TrainTestUtil.kt
@@ -3,8 +3,7 @@ package edu.wpi.axon.training.testutil
 import arrow.core.Tuple3
 import arrow.fx.IO
 import edu.wpi.axon.tfdata.Model
-import edu.wpi.axon.tflayerloader.DefaultLayersToGraph
-import edu.wpi.axon.tflayerloader.LoadLayersFromHDF5
+import edu.wpi.axon.tflayerloader.ModelLoaderFactory
 import io.kotlintest.assertions.arrow.either.shouldBeRight
 import io.kotlintest.matchers.file.shouldExist
 import io.kotlintest.matchers.string.shouldNotBeEmpty
@@ -26,8 +25,7 @@ private val LOGGER = KotlinLogging.logger("training-test-util")
  */
 fun loadModel(modelName: String, stub: () -> Unit): Pair<Model, String> {
     val localModelPath = Paths.get(stub::class.java.getResource(modelName).toURI()).toString()
-    val layers = LoadLayersFromHDF5(DefaultLayersToGraph())
-        .load(File(localModelPath))
+    val layers = ModelLoaderFactory().createModeLoader(localModelPath).load(File(localModelPath))
     val model = layers.attempt().unsafeRunSync()
     model.shouldBeRight()
     return model.b as Model to localModelPath

--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/service/JobService.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/service/JobService.kt
@@ -10,8 +10,7 @@ import edu.wpi.axon.tfdata.Dataset
 import edu.wpi.axon.tfdata.Model
 import edu.wpi.axon.tfdata.loss.Loss
 import edu.wpi.axon.tfdata.optimizer.Optimizer
-import edu.wpi.axon.tflayerloader.DefaultLayersToGraph
-import edu.wpi.axon.tflayerloader.LoadLayersFromHDF5
+import edu.wpi.axon.tflayerloader.ModelLoaderFactory
 import edu.wpi.axon.ui.JobRunner
 import java.io.File
 import java.nio.file.Paths
@@ -52,8 +51,7 @@ object JobService {
 
     private fun loadModel(modelName: String): Pair<Model, String> {
         val localModelPath = Paths.get("/home/salmon/Documents/Axon/training/src/test/resources/edu/wpi/axon/training/$modelName").toString()
-        val layers = LoadLayersFromHDF5(DefaultLayersToGraph())
-            .load(File(localModelPath))
+        val layers = ModelLoaderFactory().createModeLoader(localModelPath).load(File(localModelPath))
         val model = layers.attempt().unsafeRunSync()
         check(model is Either.Right)
         return model.b to localModelPath


### PR DESCRIPTION
### Description of the Change

This PR extracts a `ModelLoader` interface from the old class `LoadLayersFromHDF5`.

### Motivation

Axon should not be tied strictly to loading a model from an HDF5 file. This is the way we can add support for new model formats in the future.

### Verification Process

CI tests.

### Applicable Issues

None.
