### PR TITLE
Fix missing binding in the job editor form

### DIFF
--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/jobs/JobEditorForm.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/jobs/JobEditorForm.kt
@@ -72,7 +72,7 @@ class JobEditorForm : KComposite(), KoinComponent {
                     formItem("Name") {
                         textField {
                             setWidthFull()
-                            bind(binder).asRequired()
+                            bind(binder).asRequired().bind(Job::name)
                         }
                     }
                     formItem("Dataset") {


### PR DESCRIPTION
### Description of the Change

This PR fixes a missing binding in the job editor form that cause issue #137. It looks like this got accidentally deleted.

### Motivation

This causes issue #137.

### Verification Process

Tested manually.

### Applicable Issues

Closes #137.
