### PR TITLE
Add a status polling delay preference

### DIFF
--- a/aws/src/main/kotlin/edu/wpi/axon/aws/preferences/Preferences.kt
+++ b/aws/src/main/kotlin/edu/wpi/axon/aws/preferences/Preferences.kt
@@ -9,10 +9,12 @@ import software.amazon.awssdk.services.ec2.model.InstanceType
  * The user's preferences.
  *
  * @param defaultEC2NodeType The default EC2 node type to run training scripts in.
+ * @param statusPollingDelay The time in milliseconds between training status polls.
  */
 @Serializable
 data class Preferences(
-    var defaultEC2NodeType: InstanceType = InstanceType.T2_MICRO
+    var defaultEC2NodeType: InstanceType = InstanceType.T2_MICRO,
+    var statusPollingDelay: Long = 5000
 ) {
 
     fun serialize(): String = Json(

--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/jobs/JobEditorForm.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/jobs/JobEditorForm.kt
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.dependency.StyleSheet
 import com.vaadin.flow.component.formlayout.FormLayout
 import com.vaadin.flow.component.icon.Icon
 import com.vaadin.flow.component.icon.VaadinIcon
+import edu.wpi.axon.aws.preferences.PreferencesManager
 import edu.wpi.axon.db.JobDb
 import edu.wpi.axon.dbdata.Job
 import edu.wpi.axon.dbdata.TrainingScriptProgress
@@ -36,6 +37,7 @@ import edu.wpi.axon.ui.JobRunner
 import kotlin.concurrent.thread
 import mu.KotlinLogging
 import org.koin.core.KoinComponent
+import org.koin.core.get
 import org.koin.core.inject
 
 @StyleSheet("styles/job-form.css")
@@ -160,7 +162,7 @@ class JobEditorForm : KComposite(), KoinComponent {
                 IO.fx {
                     jobDb.update(job.copy(status = TrainingScriptProgress.Creating))
 
-                    val jobRunner = JobRunner()
+                    val jobRunner = JobRunner(get<PreferencesManager>().get().statusPollingDelay)
                     val id = jobRunner.startJob(job).bind()
                     LOGGER.info { "Started job with id: $id" }
 

--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
@@ -5,8 +5,11 @@ import com.github.mvysny.karibudsl.v10.beanValidationBinder
 import com.github.mvysny.karibudsl.v10.bind
 import com.github.mvysny.karibudsl.v10.button
 import com.github.mvysny.karibudsl.v10.comboBox
+import com.github.mvysny.karibudsl.v10.numberField
 import com.github.mvysny.karibudsl.v10.onLeftClick
+import com.github.mvysny.karibudsl.v10.toLong
 import com.github.mvysny.karibudsl.v10.verticalLayout
+import com.vaadin.flow.data.binder.ValidationResult
 import com.vaadin.flow.router.PageTitle
 import com.vaadin.flow.router.Route
 import edu.wpi.axon.aws.preferences.Preferences
@@ -33,6 +36,22 @@ class PreferencesView : KComposite(), HasNotifications, KoinComponent {
                     isRequired = true
                     placeholder = InstanceType.T2_MICRO.toString()
                     bind(binder).asRequired().bind(Preferences::defaultEC2NodeType)
+                }
+
+                numberField("Status Polling Delay (ms)") {
+                    // TODO: This element isn't wide enough for the label
+                    isPreventInvalidInput = true
+                    placeholder = "5000"
+                    bind(binder)
+                        .asRequired()
+                        .toLong()
+                        .withValidator { value, _ ->
+                            if (value != null && value > 0) {
+                                ValidationResult.ok()
+                            } else {
+                                ValidationResult.error("must be greater than zero.")
+                            }
+                        }.bind(Preferences::statusPollingDelay)
                 }
 
                 button("Save") {

--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
@@ -5,7 +5,6 @@ import com.github.mvysny.karibudsl.v10.beanValidationBinder
 import com.github.mvysny.karibudsl.v10.bind
 import com.github.mvysny.karibudsl.v10.button
 import com.github.mvysny.karibudsl.v10.comboBox
-import com.github.mvysny.karibudsl.v10.isExpand
 import com.github.mvysny.karibudsl.v10.numberField
 import com.github.mvysny.karibudsl.v10.onLeftClick
 import com.github.mvysny.karibudsl.v10.toLong

--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
@@ -34,14 +34,12 @@ class PreferencesView : KComposite(), HasNotifications, KoinComponent {
                     setItems(InstanceType.knownValues().stream().sorted())
                     isPreventInvalidInput = true
                     isRequired = true
-                    placeholder = InstanceType.T2_MICRO.toString()
                     bind(binder).asRequired().bind(Preferences::defaultEC2NodeType)
                 }
 
                 numberField("Status Polling Delay (ms)") {
                     // TODO: This element isn't wide enough for the label
                     isPreventInvalidInput = true
-                    placeholder = "5000"
                     bind(binder)
                         .asRequired()
                         .toLong()

--- a/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
+++ b/ui-vaadin/src/main/kotlin/edu/wpi/axon/ui/view/preferences/PreferencesView.kt
@@ -5,6 +5,7 @@ import com.github.mvysny.karibudsl.v10.beanValidationBinder
 import com.github.mvysny.karibudsl.v10.bind
 import com.github.mvysny.karibudsl.v10.button
 import com.github.mvysny.karibudsl.v10.comboBox
+import com.github.mvysny.karibudsl.v10.isExpand
 import com.github.mvysny.karibudsl.v10.numberField
 import com.github.mvysny.karibudsl.v10.onLeftClick
 import com.github.mvysny.karibudsl.v10.toLong
@@ -38,7 +39,7 @@ class PreferencesView : KComposite(), HasNotifications, KoinComponent {
                 }
 
                 numberField("Status Polling Delay (ms)") {
-                    // TODO: This element isn't wide enough for the label
+                    width = "12em"
                     isPreventInvalidInput = true
                     bind(binder)
                         .asRequired()

--- a/ui-vaadin/src/test/kotlin/edu/wpi/axon/ui/JobRunnerIntegTest.kt
+++ b/ui-vaadin/src/test/kotlin/edu/wpi/axon/ui/JobRunnerIntegTest.kt
@@ -51,7 +51,7 @@ internal class JobRunnerIntegTest : KoinTestFixture() {
             false
         )
 
-        val jobRunner = JobRunner()
+        val jobRunner = JobRunner(5000)
         jobRunner.startJob(job).flatMap { id ->
             jobRunner.waitForCompleted(id) { println(it) }
         }.unsafeRunSync()
@@ -104,7 +104,7 @@ internal class JobRunnerIntegTest : KoinTestFixture() {
             false
         )
 
-        val jobRunner = JobRunner()
+        val jobRunner = JobRunner(5000)
         jobRunner.startJob(job).flatMap { id ->
             jobRunner.waitForCompleted(id) { println(it) }
         }.unsafeRunSync()

--- a/ui-vaadin/src/test/kotlin/edu/wpi/axon/ui/JobRunnerTest.kt
+++ b/ui-vaadin/src/test/kotlin/edu/wpi/axon/ui/JobRunnerTest.kt
@@ -9,9 +9,7 @@ import edu.wpi.axon.util.axonBucketName
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifyAll
-import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Timeout
 import org.koin.core.context.startKoin
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -19,37 +17,6 @@ import org.koin.dsl.module
 internal class JobRunnerTest : KoinTestFixture() {
 
     @Test
-    @Timeout(value = 1L, unit = TimeUnit.MINUTES) // This test will timeout if it fails
-    fun `test waitForChange`() {
-        val id = 1L
-
-        val mockTrainingScriptRunner = mockk<TrainingScriptRunner> {
-            every { getTrainingProgress(id) }.returnsMany(
-                TrainingScriptProgress.NotStarted,
-                TrainingScriptProgress.NotStarted,
-                TrainingScriptProgress.Creating
-            )
-        }
-
-        startKoin {
-            modules(module {
-                single<Option<String>>(named(axonBucketName)) { None }
-                single { mockTrainingScriptRunner }
-            })
-        }
-
-        val jobRunner = JobRunner()
-        jobRunner.waitForChange(id, TrainingScriptProgress.NotStarted).unsafeRunSync()
-
-        verifyAll {
-            mockTrainingScriptRunner.getTrainingProgress(id)
-            mockTrainingScriptRunner.getTrainingProgress(id)
-            mockTrainingScriptRunner.getTrainingProgress(id)
-        }
-    }
-
-    @Test
-    @Timeout(value = 1L, unit = TimeUnit.MINUTES) // This test will timeout if it fails
     fun `test waitForCompleted`() {
         val id = 1L
 
@@ -68,7 +35,7 @@ internal class JobRunnerTest : KoinTestFixture() {
             })
         }
 
-        val jobRunner = JobRunner()
+        val jobRunner = JobRunner(1)
         jobRunner.waitForCompleted(id) {}.unsafeRunSync()
 
         verifyAll {


### PR DESCRIPTION
### Description of the Change

This PR moves the status polling delay from `JobRunner` into the preferences.

Before merge:
- [x] Make the number field wider to fit its label

### Motivation

I think the user should be able to configure this. Also, it makes the unit test for `waitForCompleted` run much faster because I can set the delay to 1ms for the test.

### Verification Process

Tested by hand.

### Applicable Issues

None.
